### PR TITLE
Fixed the first chapter error due to a missing backslash

### DIFF
--- a/src/en/readfromnet/src/eu/kanade/tachiyomi/extension/en/readfromnet/ReadFromNet.kt
+++ b/src/en/readfromnet/src/eu/kanade/tachiyomi/extension/en/readfromnet/ReadFromNet.kt
@@ -146,8 +146,7 @@ class ReadFromNet :
     override fun chapterListParse(response: Response): List<SChapter> {
         val doc = response.asJsoup()
         val chapters = mutableListOf<SChapter>()
-        val novelPath = response.request.url.encodedPath.trimStart('/')
-
+        val novelPath = response.request.url.encodedPath
         // LN Reader: First chapter is the page itself (page 1)
         chapters.add(
             SChapter.create().apply {


### PR DESCRIPTION
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
