### PR TITLE
fix(fenrirealm): correct title and filter handling

### DIFF
--- a/src/en/fenrirealm/build.gradle
+++ b/src/en/fenrirealm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Fenrirealm'
     extClass = '.Fenrirealm'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
+++ b/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
@@ -110,7 +110,22 @@ class Fenrirealm :
 
     override fun mangaDetailsParse(response: Response): SManga {
         val result = json.decodeFromString<SearchResponse>(response.body.string())
-        return result.data.firstOrNull()?.toSManga(baseUrl) ?: SManga.create()
+        result.data.firstOrNull()?.let { return it.toSManga(baseUrl) }
+
+        val searchedSlug = response.request.url.queryParameter("search")
+            ?.trim()
+            ?.removePrefix("/")
+            ?.removeSuffix("/")
+            .orEmpty()
+
+        return SManga.create().apply {
+            url = if (searchedSlug.isNotBlank()) "/$searchedSlug" else "/"
+            title = searchedSlug
+                .substringAfterLast('/')
+                .replace('-', ' ')
+                .trim()
+                .ifBlank { "Unknown Title" }
+        }
     }
 
     override fun chapterListRequest(manga: SManga): Request {


### PR DESCRIPTION
Fix title parsing from search results and standardize filter configuration. Improves metadata accuracy and filter UX.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
