### PR TITLE
feat(zetrotranslation): add locked chapter preference

### DIFF
--- a/src/en/zetrotranslation/build.gradle
+++ b/src/en/zetrotranslation/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ZetroTranslation'
     themePkg = 'madaranovel'
     baseUrl = 'https://zetrotranslation.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/zetrotranslation/src/eu/kanade/tachiyomi/extension/en/zetrotranslation/ZetroTranslation.kt
+++ b/src/en/zetrotranslation/src/eu/kanade/tachiyomi/extension/en/zetrotranslation/ZetroTranslation.kt
@@ -1,12 +1,52 @@
 ﻿package eu.kanade.tachiyomi.extension.en.zetrotranslation
 
+import android.app.Application
+import android.content.SharedPreferences
+import androidx.preference.CheckBoxPreference
+import androidx.preference.PreferenceScreen
 import eu.kanade.tachiyomi.multisrc.madaranovel.MadaraNovel
+import eu.kanade.tachiyomi.source.ConfigurableSource
+import eu.kanade.tachiyomi.source.model.SChapter
+import okhttp3.Response
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class ZetroTranslation :
     MadaraNovel(
         baseUrl = "https://zetrotranslation.com",
         name = "Zetro Translation",
         lang = "en",
-    ) {
+    ),
+    ConfigurableSource {
     override val reverseChapterListDefault = true
+
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
+
+    private val excludeLocked: Boolean
+        get() = preferences.getBoolean(PREF_EXCLUDE_LOCKED, false)
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        CheckBoxPreference(screen.context).apply {
+            key = PREF_EXCLUDE_LOCKED
+            title = "Exclude locked chapters"
+            summary = "Hide chapters that require payment"
+            setDefaultValue(false)
+        }.also(screen::addPreference)
+    }
+
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val list = super.chapterListParse(response)
+        if (!excludeLocked) return list
+
+        return list.filterNot { ch ->
+            val name = ch.name ?: ""
+            name.contains("🔒") || name.contains("paid", true) || name.contains("vip", true) || name.contains("locked", true)
+        }
+    }
+
+    companion object {
+        private const val PREF_EXCLUDE_LOCKED = "zetrotranslation_exclude_locked"
+    }
 }


### PR DESCRIPTION
Add UI option to show/hide locked premium chapters. Allows users to configure content filtering based on preference.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
