### PR TITLE
fix(novelbin): improve pagination

### DIFF
--- a/src/en/novelbin/build.gradle
+++ b/src/en/novelbin/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NovelBin'
     themePkg = 'readnovelfull'
     baseUrl = 'https://novelbin.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/novelbin/src/eu/kanade/tachiyomi/extension/en/novelbin/NovelBin.kt
+++ b/src/en/novelbin/src/eu/kanade/tachiyomi/extension/en/novelbin/NovelBin.kt
@@ -1,6 +1,7 @@
 ﻿package eu.kanade.tachiyomi.extension.en.novelbin
 
 import eu.kanade.tachiyomi.multisrc.readnovelfull.ReadNovelFull
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.asJsoup
@@ -14,6 +15,7 @@ class NovelBin :
         lang = "en",
     ) {
     override val latestPage = "sort/latest"
+    override val popularPage = "sort/top-view-novel"
 
     override fun popularMangaSelector() = "div.col-xs-12.col-md-8 div.row[itemscope], div.list-thumb div.col-xs-4, div.list-novel div.row"
 
@@ -42,6 +44,39 @@ class NovelBin :
     override fun searchMangaSelector() = popularMangaSelector()
 
     override fun searchMangaFromElement(element: Element) = popularMangaFromElement(element)
+
+    override fun popularMangaNextPageSelector() = "ul.pagination a[href], li.next:not(.disabled), ul.pagination li.active + li a"
+
+    override fun popularMangaParse(response: okhttp3.Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = document.select(popularMangaSelector()).map { popularMangaFromElement(it) }
+
+        // Common indicators
+        var hasNext = document.selectFirst("li.next:not(.disabled), ul.pagination li.active + li a") != null
+
+        if (!hasNext) {
+            val currentPage = response.request.url.queryParameter("page")?.toIntOrNull()
+                ?: response.request.url.encodedPath.substringAfterLast('/').toIntOrNull()
+                ?: 1
+
+            val anchors = document.select("ul.pagination a[href]").filter { a ->
+                val href = a.attr("href")
+                href.isNotBlank() && !href.startsWith("javascript", true)
+            }
+
+            hasNext = anchors.any { a ->
+                val text = a.text().trim()
+                val num = text.toIntOrNull()
+                if (num != null) {
+                    num > currentPage
+                } else {
+                    text.contains(">") || a.attr("rel") == "next"
+                }
+            }
+        }
+
+        return MangasPage(mangas, hasNext)
+    }
 
     override fun mangaDetailsParse(document: org.jsoup.nodes.Document): SManga = SManga.create().apply {
         document.selectFirst("div.books, div.book")?.let { info ->


### PR DESCRIPTION
Enhance page offset calculation and prevent duplicate chapter loading. Fixes edge cases in chapter list continuity.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
