### PR TITLE
fix(readwn): update shared multisrc pagination

### DIFF
--- a/src/en/fansmtl/build.gradle
+++ b/src/en/fansmtl/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.FansMTL'
     themePkg = 'readwn'
     baseUrl = 'https://www.fanmtl.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/fansmtl/src/eu/kanade/tachiyomi/extension/en/fansmtl/FansMTL.kt
+++ b/src/en/fansmtl/src/eu/kanade/tachiyomi/extension/en/fansmtl/FansMTL.kt
@@ -1,6 +1,7 @@
 ﻿package eu.kanade.tachiyomi.extension.en.fansmtl
 
 import eu.kanade.tachiyomi.multisrc.readwn.ReadWN
+import eu.kanade.tachiyomi.network.GET
 
 /**
  * FansMTL - ReadWN-based novel site
@@ -11,4 +12,15 @@ class FansMTL :
         name = "Fans MTL",
         baseUrl = "https://www.fanmtl.com",
         lang = "en",
-    )
+    ) {
+    // Use the same pagination/list patterns as Wuxiabox for consistency
+    override fun popularMangaRequest(page: Int) = GET("$baseUrl/list/all/all-onclick-${page - 1}.html", headers)
+
+    override fun latestUpdatesRequest(page: Int) = GET("$baseUrl/list/all/all-lastdotime-${page - 1}.html", headers)
+
+    override fun popularMangaNextPageSelector() = "nav.paging ul.pagination li a[href]"
+
+    override fun latestUpdatesNextPageSelector() = popularMangaNextPageSelector()
+
+    override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
+}

--- a/src/en/wuxiabox/build.gradle
+++ b/src/en/wuxiabox/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Wuxiabox'
     themePkg = 'readwn'
     baseUrl = 'https://wuxiabox.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/wuxiabox/src/eu/kanade/tachiyomi/extension/en/wuxiabox/Wuxiabox.kt
+++ b/src/en/wuxiabox/src/eu/kanade/tachiyomi/extension/en/wuxiabox/Wuxiabox.kt
@@ -1,5 +1,27 @@
 package eu.kanade.tachiyomi.extension.en.wuxiabox
 
 import eu.kanade.tachiyomi.multisrc.readwn.ReadWN
+import eu.kanade.tachiyomi.network.GET
+import okhttp3.Request
 
-class Wuxiabox : ReadWN("Wuxiabox", "https://wuxiabox.com", "en")
+class Wuxiabox : ReadWN("Wuxiabox", "https://wuxiabox.com", "en") {
+    // Wuxiabox uses the "all-onclick" pagination for popular (sort by Popular)
+    override fun popularMangaRequest(page: Int): Request {
+        val idx = page - 1
+        return GET("$baseUrl/list/all/all-onclick-$idx.html", headers)
+    }
+
+    // Latest/Updates use the lastdotime sort
+    override fun latestUpdatesRequest(page: Int): Request {
+        val idx = page - 1
+        return GET("$baseUrl/list/all/all-lastdotime-$idx.html", headers)
+    }
+
+    // Pagination uses nav.paging > ul.pagination > li > a
+    override fun popularMangaNextPageSelector() = "nav.paging ul.pagination li a[href]"
+
+    override fun latestUpdatesNextPageSelector() = popularMangaNextPageSelector()
+
+    // Search/filter results also use the same pagination; enable next-page for searches
+    override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
+}

--- a/src/en/wuxiaspace/build.gradle
+++ b/src/en/wuxiaspace/build.gradle
@@ -3,8 +3,9 @@ ext {
     extClass = '.WuxiaSpace'
     themePkg = 'readwn'
     baseUrl = 'https://www.wuxiaspot.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
+    isNovel = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/wuxiaspace/src/eu/kanade/tachiyomi/extension/en/wuxiaspace/WuxiaSpace.kt
+++ b/src/en/wuxiaspace/src/eu/kanade/tachiyomi/extension/en/wuxiaspace/WuxiaSpace.kt
@@ -2,4 +2,8 @@ package eu.kanade.tachiyomi.extension.en.wuxiaspace
 
 import eu.kanade.tachiyomi.multisrc.readwn.ReadWN
 
-class WuxiaSpace : ReadWN("Wuxia Space", "https://www.wuxiaspot.com", "en")
+class WuxiaSpace : ReadWN("Wuxia Space", "https://www.wuxiaspot.com", "en") {
+    override fun popularMangaNextPageSelector() = ".paging .pagination a[href]:matchesOwn(^>$)"
+
+    override fun searchMangaNextPageSelector() = ".paging .pagination a[href]:matchesOwn(^>$)"
+}


### PR DESCRIPTION
Correct page offset calculation and prevent pagination loops. Aligns with updated site structure.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
