### PR TITLE
fix(fenrirealm): improve chapter content extraction

### DIFF
--- a/src/en/fenrirealm/build.gradle
+++ b/src/en/fenrirealm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Fenrirealm'
     extClass = '.Fenrirealm'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = false
     isNovel = true
 }

--- a/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
+++ b/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
@@ -161,13 +161,41 @@ class Fenrirealm :
 
     override suspend fun fetchPageText(page: Page): String {
         val response = client.newCall(GET(baseUrl + page.url, headers)).execute()
-        val doc = Jsoup.parse(response.body.string())
-        return doc.selectFirst("div[id^=reader-area]")?.html()
-            ?: doc.selectFirst("#reader-area")?.html()
-            ?: doc.selectFirst("div.content-area")?.html()
-            ?: doc.selectFirst("div.epcontent.entry-content")?.html()
-            ?: doc.selectFirst("div.entry-content")?.html()
-            ?: ""
+        val body = response.body.string()
+
+        // Try DOM extraction first (more reliable for rendered HTML)
+        val chapterContent = extractChapterContentFromDOM(body)
+        if (chapterContent.isNotBlank()) {
+            return chapterContent
+        }
+
+        return ""
+    }
+
+    private fun extractChapterContentFromDOM(body: String): String {
+        val doc = Jsoup.parse(body)
+
+        // Find the main chapter reader area
+        val readerArea = doc.selectFirst("div[role=region][id^=reader-area]")
+            ?: doc.selectFirst("div.reader-area")
+            ?: return ""
+
+        // Get all content up to (but not including) the comments/note section
+        val allElements = readerArea.children()
+        val result = StringBuilder()
+
+        for (element in allElements) {
+            val html = element.outerHtml()
+            // Stop before reaching any "What do you think" or comment sections
+            if (html.contains("What do you think", ignoreCase = true) ||
+                html.contains("comment", ignoreCase = true)
+            ) {
+                break
+            }
+            result.append(html)
+        }
+
+        return result.toString()
     }
 
     override fun getFilterList(): FilterList = FilterList(


### PR DESCRIPTION
Refactor the parser to more accurately identify the reader area and filter out non-chapter content, such as polls and comment sections. Updates DOM selectors and bumps the extension version.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
