### PR TITLE
fix(wtrlab): improve glossary parsing and set default keys

### DIFF
--- a/src/en/wtrlab/build.gradle
+++ b/src/en/wtrlab/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'WTR-LAB'
     extClass = '.WtrLab'
-    extVersionCode = 3
+    extVersionCode = 4
     isNovel = true
 }
 

--- a/src/en/wtrlab/src/eu/kanade/tachiyomi/extension/en/wtrlab/WtrLab.kt
+++ b/src/en/wtrlab/src/eu/kanade/tachiyomi/extension/en/wtrlab/WtrLab.kt
@@ -16,6 +16,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.setAltTitles
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -576,28 +577,62 @@ class WtrLab :
         val nextDataText = nextDataElement?.data()
 
         val manga = SManga.create()
+        var altTitles = listOf<String>()
 
         if (nextDataText != null) {
             try {
                 val jsonData = json.parseToJsonElement(nextDataText).jsonObject
-                val serieData = jsonData["props"]?.jsonObject
-                    ?.get("pageProps")?.jsonObject
-                    ?.get("serie")?.jsonObject
+                val pageProps = jsonData["props"]?.jsonObject?.get("pageProps")?.jsonObject
+                val serieData = pageProps?.get("serie")?.jsonObject
                     ?.get("serie_data")?.jsonObject
 
                 if (serieData != null) {
                     val data = serieData["data"]?.jsonObject
                     manga.title = data?.get("title")?.jsonPrimitive?.contentOrNull ?: ""
                     manga.thumbnail_url = transformImageUrl(data?.get("image")?.jsonPrimitive?.contentOrNull)
-                    manga.description = data?.get("description")?.jsonPrimitive?.contentOrNull?.let {
-                        Jsoup.parse(it).text()
+
+                    // Preserve paragraph breaks in description
+                    val description = data?.get("description")?.jsonPrimitive?.contentOrNull?.let {
+                        it.replace("\\n", "\n").trim()
+                    } ?: ""
+
+                    // Extract metadata
+                    val rating = serieData["rating"]?.jsonPrimitive?.contentOrNull ?: "N/A"
+                    val charCount = serieData["char_count"]?.jsonPrimitive?.intOrNull ?: 0
+                    val readers = serieData["in_library"]?.jsonPrimitive?.intOrNull ?: 0
+                    val reviewCount = serieData["total_rate"]?.jsonPrimitive?.intOrNull ?: 0
+
+                    // Build metadata section
+                    val metadata = buildString {
+                        append("Rating: $rating\n")
+                        append("Readers: $readers\n")
+                        append("Reviews: $reviewCount")
+                        if (charCount > 0) {
+                            append("\n")
+                            append("Characters: $charCount")
+                        }
                     }
+
+                    manga.description = if (description.isNotEmpty()) {
+                        "$metadata\n\n$description"
+                    } else {
+                        metadata
+                    }
+
                     manga.author = data?.get("author")?.jsonPrimitive?.contentOrNull
 
                     manga.status = when (serieData["status"]?.jsonPrimitive?.intOrNull) {
                         0 -> SManga.ONGOING
                         1 -> SManga.COMPLETED
                         else -> SManga.UNKNOWN
+                    }
+                }
+
+                // Extract alternative titles
+                val names = pageProps?.get("names")?.jsonArray
+                if (names != null && names.size > 1) {
+                    altTitles = names.mapNotNull { nameElem ->
+                        nameElem.jsonObject["raw_title"]?.jsonPrimitive?.contentOrNull
                     }
                 }
             } catch (e: Exception) {
@@ -670,6 +705,11 @@ class WtrLab :
         if (allTags.isNotEmpty()) {
             val combinedGenres = (genres + allTags).filter { it.isNotEmpty() }.distinctBy { it.lowercase() }
             manga.genre = combinedGenres.joinToString(", ")
+        }
+
+        // Set alternative titles if available
+        if (altTitles.isNotEmpty()) {
+            manga.setAltTitles(altTitles)
         }
 
         return manga

--- a/src/en/wtrlab/src/eu/kanade/tachiyomi/extension/en/wtrlab/WtrLab.kt
+++ b/src/en/wtrlab/src/eu/kanade/tachiyomi/extension/en/wtrlab/WtrLab.kt
@@ -351,18 +351,64 @@ class WtrLab :
 
     private fun replaceGlossarySymbols(content: String, terms: JsonArray): String {
         var result = content
-        terms.forEachIndexed { index, term ->
-            val termArray = term.jsonArray
-            val englishTranslations = termArray.getOrNull(0)
-            val english = when (englishTranslations) {
-                is JsonArray -> englishTranslations.firstOrNull()?.jsonPrimitive?.contentOrNull
-                is JsonElement -> englishTranslations.jsonPrimitive.contentOrNull
-                else -> null
-            } ?: return@forEachIndexed
 
-            val symbol = "※$index⛬"
-            result = result.replace(symbol, english)
+        terms.forEachIndexed { index, term ->
+            try {
+                // Safely extract the term array
+                val termArray = when (term) {
+                    is JsonElement -> {
+                        try {
+                            term.jsonArray
+                        } catch (e: Exception) {
+                            Log.w("WtrLab", "Term at index $index is not a JsonArray")
+                            return@forEachIndexed
+                        }
+                    }
+                    else -> return@forEachIndexed
+                }
+
+                // Extract English translation (first element)
+                val englishTranslations = termArray.getOrNull(0)
+                val english = when (englishTranslations) {
+                    is JsonArray -> englishTranslations.firstOrNull()?.jsonPrimitive?.contentOrNull?.trim()
+                    is JsonElement -> englishTranslations.jsonPrimitive.contentOrNull?.trim()
+                    else -> null
+                }
+
+                if (english.isNullOrBlank()) {
+                    return@forEachIndexed
+                }
+
+                // Create pattern to match symbols with BOTH endings: ⛬ and 〓
+                // The regex pattern captures both characters in a character class
+                val symbolPatterns = listOf(
+                    // Direct Unicode variants (⛬ = U+26EC, 〓 = U+3013)
+                    "※$index[⛬〓]", // No whitespace
+                    "※\\s*$index\\s*[⛬〓]", // With optional whitespace
+
+                    // HTML entity encoding for ⛬ (&#x26ec; or &#x26EC;)
+                    "&#x203b;$index&#x26ec;",
+                    "&#x203b;\\s*$index\\s*&#x26ec;",
+                    "&#x203b;$index&#x26EC;",
+                    "&#x203b;\\s*$index\\s*&#x26EC;",
+
+                    // HTML entity encoding for 〓 (&#x3013; or &#x3013;)
+                    "&#x203b;$index&#x3013;",
+                    "&#x203b;\\s*$index\\s*&#x3013;",
+                )
+
+                // Replace all pattern variations
+                for (pattern in symbolPatterns) {
+                    result = result.replace(
+                        Regex(pattern, RegexOption.IGNORE_CASE),
+                        Regex.escapeReplacement(english),
+                    )
+                }
+            } catch (e: Exception) {
+                Log.w("WtrLab", "Error processing glossary term at index $index: ${e.message}")
+            }
         }
+
         return result
     }
 
@@ -753,6 +799,7 @@ class WtrLab :
             summary = "Required for Raw/Web modes. Enter the AES encryption key."
             dialogTitle = "Decryption Key"
             dialogMessage = "Enter the 32-character decryption key for encrypted content."
+            setDefaultValue("IJAFUUxjM25hyzL2AZrn0wl7cESED6Ru")
         }.also(screen::addPreference)
 
         androidx.preference.EditTextPreference(screen.context).apply {
@@ -761,6 +808,7 @@ class WtrLab :
             summary = "Optional. Google Translate API key for future use."
             dialogTitle = "Google API Key"
             dialogMessage = "Enter your Google Translate API key."
+            setDefaultValue("AIzaSyATBXajvzQLTDHEQbcpq0Ihe0vWDHmO520")
         }.also(screen::addPreference)
     }
 


### PR DESCRIPTION
Enhance `replaceGlossarySymbols` to handle multiple symbol variants (⛬, 〓), optional whitespace, and HTML entity encodings. Add robust JSON extraction with error handling for glossary terms and set default values for decryption and Google API keys in preferences.

- Improve regex patterns for glossary symbol replacement
- Add safety checks and logging to glossary processing
- Set default configuration keys
- Bump version code
Include default keys included in the website for google api/decryption
Checklist:

- [ ] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [ ] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [ ] Have tested the modifications by compiling and running the extension through Android Studio
- [ ] Have removed `web_hi_res_512.png` when adding a new extension
