### PR TITLE
feat(madaranovel): implement library tracking and improve parsing

### DIFF
--- a/lib-multisrc/madaranovel/build.gradle.kts
+++ b/lib-multisrc/madaranovel/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/madaranovel/src/eu/kanade/tachiyomi/multisrc/madaranovel/MadaraNovel.kt
+++ b/lib-multisrc/madaranovel/src/eu/kanade/tachiyomi/multisrc/madaranovel/MadaraNovel.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.NovelSource
+import eu.kanade.tachiyomi.source.SourceTracker
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
@@ -21,6 +22,7 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
 import uy.kohesive.injekt.injectLazy
 import java.util.Calendar
 
@@ -35,7 +37,8 @@ open class MadaraNovel(
     override val lang: String = "en",
 ) : HttpSource(),
     NovelSource,
-    ConfigurableSource {
+    ConfigurableSource,
+    SourceTracker {
 
     override val isNovelSource = true
 
@@ -217,6 +220,9 @@ open class MadaraNovel(
 
         doc.select(".manga-title-badges, #manga-title span").remove()
 
+        // Cache the WP post id for tracking (bookmark/history) calls later
+        extractPostId(doc)?.let { cachePostId(response.request.url.encodedPath, it) }
+
         return SManga.create().apply {
             title = doc.selectFirst(".post-title h1, #manga-title h1")?.text()?.trim() ?: ""
 
@@ -230,9 +236,9 @@ open class MadaraNovel(
                 null
             }
 
-            description = doc.selectFirst("div.summary__content")?.text()?.trim()
-                ?: doc.selectFirst("#tab-manga-about")?.text()?.trim()
-                ?: doc.selectFirst(".manga-excerpt")?.text()?.trim()
+            description = doc.selectFirst("div.summary__content")?.formattedDescription()
+                ?: doc.selectFirst("#tab-manga-about")?.formattedDescription()
+                ?: doc.selectFirst(".manga-excerpt")?.formattedDescription()
                 ?: ""
             author = doc.selectFirst(".manga-authors")?.text()?.trim()
                 ?: doc.select(".post-content_item, .post-content")
@@ -263,11 +269,34 @@ open class MadaraNovel(
         }
     }
 
+    /**
+     * Extracts the WordPress post id of a novel from its page.
+     * Used both for the old chapter list endpoint and tracking calls.
+     */
+    protected fun extractPostId(doc: Document): String? = doc.selectFirst(".rating-post-id")?.attr("value")?.ifEmpty { null }
+        ?: doc.selectFirst("#manga-chapters-holder")?.attr("data-id")?.ifEmpty { null }
+        ?: doc.selectFirst("a[data-post-id]")?.attr("data-post-id")?.ifEmpty { null }
+        // Fallback: extract from shortlink (e.g., <link rel="shortlink" href="...?p=91245">)
+        ?: doc.selectFirst("link[rel=shortlink]")?.attr("href")
+            ?.let { Regex("""[?&]p=(\d+)""").find(it)?.groupValues?.get(1) }
+
+    // "Chapter 12", "Ch. 12.5 - Title", "Episode 3: Title"
+    private val chapterPrefixRegex =
+        Regex("""^(?:chapter|chap|ch|episode|ep)\.?\s*(\d+(?:\.\d+)?)\s*[-–—:.]?\s*""", RegexOption.IGNORE_CASE)
+
+    // "12 - Title" (bare number requires an explicit separator so titles that
+    // merely start with a number aren't eaten)
+    private val numberSeparatorRegex = Regex("""^(\d+(?:\.\d+)?)\s*[-–—:]\s*""")
+
     override fun chapterListRequest(manga: SManga): Request = GET(baseUrl + manga.url, headers)
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val doc = response.asJsoup()
         val mangaUrl = response.request.url.encodedPath
+
+        // Cache the WP post id for tracking (bookmark/history) calls later
+        val postId = extractPostId(doc)
+        postId?.let { cachePostId(mangaUrl, it) }
 
         val chapters = mutableListOf<SChapter>()
         var html: String
@@ -282,17 +311,9 @@ open class MadaraNovel(
             ).execute()
             html = chapResponse.body.string()
         } else {
-            // Extract novel ID from various sources
-            val novelId = doc.selectFirst(".rating-post-id")?.attr("value")
-                ?: doc.selectFirst("#manga-chapters-holder")?.attr("data-id")
-                // Fallback: extract from shortlink (e.g., <link rel="shortlink" href="...?p=91245">)
-                ?: doc.selectFirst("link[rel=shortlink]")?.attr("href")
-                    ?.let { Regex("""[?&]p=(\d+)""").find(it)?.groupValues?.get(1) }
-                ?: ""
-
             val formBody = FormBody.Builder()
                 .add("action", "manga_get_chapters")
-                .add("manga", novelId)
+                .add("manga", postId ?: "")
                 .build()
 
             val chapResponse = client.newCall(
@@ -307,8 +328,17 @@ open class MadaraNovel(
 
             chapDoc.select(".wp-manga-chapter").forEachIndexed { index, element ->
                 try {
-                    var chapterName = element.selectFirst("a")?.text()?.trim() ?: return@forEachIndexed
+                    val rawName = element.selectFirst("a")?.text()?.trim() ?: return@forEachIndexed
                     val isLocked = element.className().contains("premium-block")
+
+                    // The app shows the chapter number separately from the title,
+                    // so strip "Chapter 12 - " style prefixes from the displayed name
+                    val numberMatch = chapterPrefixRegex.find(rawName)
+                        ?: numberSeparatorRegex.find(rawName)
+                    val parsedNumber = numberMatch?.groupValues?.get(1)?.toFloatOrNull()
+                    var chapterName = numberMatch?.let { rawName.removeRange(it.range).trim() }
+                        ?.ifEmpty { null }
+                        ?: rawName
 
                     if (isLocked) {
                         chapterName = "🔒 $chapterName"
@@ -340,7 +370,7 @@ open class MadaraNovel(
                                 url = relativeChapterUrl
                                 name = chapterName
                                 date_upload = parseDate(releaseDate)
-                                chapter_number = (totalChaps - index).toFloat()
+                                chapter_number = parsedNumber ?: (totalChaps - index).toFloat()
                             },
                         )
                     }
@@ -453,6 +483,204 @@ open class MadaraNovel(
 
     protected fun Response.asJsoup(): Document = Jsoup.parse(body.string())
 
+    // ======================== Tracking ========================
+
+    /**
+     * Set to false in a subclass to disable chapter read syncing for that source,
+     * e.g. if the site removed the wp-manga user history AJAX endpoint.
+     */
+    protected open val chapterTrackingSupported = true
+
+    /**
+     * Set to false in a subclass to disable favorites/bookmark syncing for that source,
+     * e.g. if the site removed the wp-manga bookmark AJAX endpoint.
+     */
+    protected open val favoritesTrackingSupported = true
+
+    private val trackingEnabled: Boolean
+        get() = preferences.getBoolean(PREF_ENABLE_TRACKING, false)
+
+    override val supportsChapterTracking: Boolean
+        get() = chapterTrackingSupported && trackingEnabled
+
+    override val supportsFavoritesTracking: Boolean
+        get() = favoritesTrackingSupported && trackingEnabled
+
+    override suspend fun onChaptersRead(
+        manga: SManga,
+        changedChapters: List<SChapter>,
+        allChapters: List<SChapter>,
+        categories: List<String>,
+    ) {
+        if (!supportsChapterTracking) return
+        val target = changedChapters
+            .filter { it.chapter_number > 0f }
+            .maxByOrNull { it.chapter_number }
+            ?: changedChapters.lastOrNull()
+            ?: return
+
+        // The site happily overwrites history with an older chapter, so guard locally
+        if (preferences.getBoolean(PREF_PROTECT_HIGHEST, true)) {
+            val cached = highestTrackedNumber(cacheKey(manga.url))
+            if (cached != null && target.chapter_number <= cached) return
+        }
+
+        val chapterSlug = target.url.substringBefore('?').trimEnd('/').substringAfterLast('/')
+        if (chapterSlug.isEmpty()) return
+
+        val postId = resolvePostId(manga) ?: return
+        // The history endpoint requires a fresh wp-manga nonce. It lives in the
+        // `var manga = {...}` JS object on the chapter reading page, so scrape it
+        // from there (with the novel page as fallback).
+        val nonce = fetchNonce(target.url) ?: fetchNonce(manga.url) ?: return
+
+        val historyBody = FormBody.Builder()
+            .add("action", "manga-user-history")
+            .add("postID", postId)
+            .add("chapterSlug", chapterSlug)
+            .add("paged", "1")
+            .add("img_id", "")
+            .add("nonce", nonce)
+            .build()
+        var anySuccess = ajaxSucceeded(historyBody)
+
+        if (preferences.getBoolean(PREF_BOOKMARK_CHAPTER, false)) {
+            val bookmarkBody = FormBody.Builder()
+                .add("action", "wp-manga-user-bookmark")
+                .add("postID", postId)
+                .add("chapter", chapterSlug)
+                .add("page", "1")
+                .build()
+            anySuccess = ajaxSucceeded(bookmarkBody) || anySuccess
+        }
+
+        if (anySuccess) {
+            recordHighestTracked(cacheKey(manga.url), target.chapter_number)
+        }
+    }
+
+    override suspend fun onFavorited(manga: SManga, categories: List<String>) {
+        if (!supportsFavoritesTracking) return
+        val postId = resolvePostId(manga) ?: return
+        val body = FormBody.Builder()
+            .add("action", "wp-manga-user-bookmark")
+            .add("postID", postId)
+            .add("chapter", "")
+            .add("page", "1")
+            .build()
+        ajaxSucceeded(body)
+    }
+
+    override suspend fun onUnfavorited(manga: SManga, categories: List<String>) {
+        if (!supportsFavoritesTracking) return
+        val postId = resolvePostId(manga) ?: return
+        val body = FormBody.Builder()
+            .add("action", "wp-manga-delete-bookmark")
+            .add("postID", postId)
+            .add("isMangaSingle", "1")
+            .build()
+        ajaxSucceeded(body)
+    }
+
+    /** Sends a wp-admin/admin-ajax.php POST and reports whether it returned {"success":true}. */
+    private fun ajaxSucceeded(body: FormBody): Boolean = try {
+        client.newCall(POST("$baseUrl/wp-admin/admin-ajax.php", headers, body)).execute().use { resp ->
+            resp.isSuccessful && resp.body.string().contains("\"success\":true")
+        }
+    } catch (e: Exception) {
+        false
+    }
+
+    /** Returns the cached post id, or scrapes the novel page when missing. */
+    private fun resolvePostId(manga: SManga): String? {
+        cachedPostId(cacheKey(manga.url))?.let { return it }
+        return try {
+            val url = baseUrl + manga.url
+            val response = client.newCall(GET(url, headers)).execute()
+            val doc = Jsoup.parse(response.use { it.body.string() }, url)
+            extractPostId(doc)?.also { cachePostId(manga.url, it) }
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Fetches a page and extracts the AJAX nonce used by manga-user-history.
+     * It lives in the `user_history-js-extra` script on chapter reading pages:
+     * `var user_history_params = {"ajax_url":"...","postID":"...","nonce":"..."}`.
+     * Pages carry several localized script objects with their own nonces
+     * (wpMangaLogin, madara, etc.) — only this one is valid for history calls.
+     */
+    private fun fetchNonce(path: String): String? = try {
+        val response = client.newCall(GET(baseUrl + path, headers)).execute()
+        val html = response.use { it.body.string() }
+        Regex("""var\s+user_history_params\s*=\s*\{[^}]*?"nonce"\s*:\s*"(\w+)"""").find(html)
+            ?.groupValues?.get(1)
+            // Fallback: the wp-manga `var manga` object's nonce
+            ?: Regex("""var\s+manga\s*=\s*\{[^}]*?"nonce"\s*:\s*"(\w+)"""").find(html)
+                ?.groupValues?.get(1)
+    } catch (e: Exception) {
+        null
+    }
+
+    private val postIdCache = mutableMapOf<String, String>()
+
+    private fun cacheKey(url: String): String = url.removePrefix(baseUrl).substringBefore('?').trimEnd('/')
+
+    private fun cachedPostId(key: String): String? {
+        synchronized(postIdCache) {
+            if (postIdCache.isEmpty()) {
+                val raw = preferences.getString(PREF_POST_ID_CACHE, "") ?: ""
+                raw.split('\n').forEach { line ->
+                    val sep = line.indexOf('|')
+                    if (sep > 0) postIdCache[line.substring(0, sep)] = line.substring(sep + 1)
+                }
+            }
+            return postIdCache[key]
+        }
+    }
+
+    protected fun cachePostId(mangaUrl: String, id: String) {
+        val key = cacheKey(mangaUrl)
+        synchronized(postIdCache) {
+            // Hydrate from prefs first so we don't clobber other entries
+            if (cachedPostId(key) == id) return
+            postIdCache[key] = id
+            val serialized = postIdCache.entries.joinToString("\n") { "${it.key}|${it.value}" }
+            preferences.edit().putString(PREF_POST_ID_CACHE, serialized).apply()
+        }
+    }
+
+    private fun highestTrackedNumber(mangaUrl: String): Float? {
+        val raw = preferences.getString(PREF_HIGHEST_CACHE, "") ?: ""
+        raw.split('\n').forEach { line ->
+            val sep = line.indexOf('|')
+            if (sep > 0 && line.substring(0, sep) == mangaUrl) {
+                return line.substring(sep + 1).toFloatOrNull()
+            }
+        }
+        return null
+    }
+
+    private fun recordHighestTracked(mangaUrl: String, value: Float) {
+        val raw = preferences.getString(PREF_HIGHEST_CACHE, "") ?: ""
+        val rebuilt = StringBuilder()
+        var replaced = false
+        raw.split('\n').filter { it.isNotEmpty() }.forEach { line ->
+            val sep = line.indexOf('|')
+            if (sep > 0 && line.substring(0, sep) == mangaUrl) {
+                if (!replaced) {
+                    rebuilt.append(mangaUrl).append('|').append(value).append('\n')
+                    replaced = true
+                }
+            } else {
+                rebuilt.append(line).append('\n')
+            }
+        }
+        if (!replaced) rebuilt.append(mangaUrl).append('|').append(value).append('\n')
+        preferences.edit().putString(PREF_HIGHEST_CACHE, rebuilt.toString()).apply()
+    }
+
     // ======================== Settings ========================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
@@ -476,12 +704,62 @@ open class MadaraNovel(
             summary = "If enabled, returns the raw HTML of the chapter content instead of parsed text. Useful for custom parsers."
             setDefaultValue(false)
         }.also(screen::addPreference)
+
+        if (chapterTrackingSupported || favoritesTrackingSupported) {
+            SwitchPreferenceCompat(screen.context).apply {
+                key = PREF_ENABLE_TRACKING
+                title = "Enable $name tracking"
+                summary = "Sync library bookmarks and reading progress to your $name account. Requires being logged in via WebView."
+                setDefaultValue(false)
+            }.also(screen::addPreference)
+
+            if (chapterTrackingSupported) {
+                SwitchPreferenceCompat(screen.context).apply {
+                    key = PREF_PROTECT_HIGHEST
+                    title = "Don't sync chapters below current"
+                    summary = "Skip syncing a chapter lower than the highest already synced for that novel. The site otherwise overwrites your history with the older chapter."
+                    setDefaultValue(true)
+                }.also(screen::addPreference)
+
+                SwitchPreferenceCompat(screen.context).apply {
+                    key = PREF_BOOKMARK_CHAPTER
+                    title = "Bookmark chapter on read"
+                    summary = "Also bookmark the chapter on the site when marking it read, updating the bookmark's chapter pointer."
+                    setDefaultValue(false)
+                }.also(screen::addPreference)
+            }
+
+            SwitchPreferenceCompat(screen.context).apply {
+                key = PREF_RESET_TRACKING_CACHE
+                title = "Reset tracking cache"
+                summary = "Toggle to clear cached post IDs and highest-synced-chapter records."
+                setDefaultValue(false)
+                setOnPreferenceChangeListener { _, newValue ->
+                    if (newValue as Boolean) {
+                        preferences.edit()
+                            .remove(PREF_POST_ID_CACHE)
+                            .remove(PREF_HIGHEST_CACHE)
+                            .apply()
+                        synchronized(postIdCache) { postIdCache.clear() }
+                        false
+                    } else {
+                        true
+                    }
+                }
+            }.also(screen::addPreference)
+        }
     }
 
     companion object {
         private const val USE_NEW_CHAPTER_ENDPOINT_PREF = "pref_use_new_chapter_endpoint"
         private const val PREF_REVERSE_CHAPTERS = "pref_reverse_chapters"
         private const val PREF_RAW_HTML = "pref_raw_html"
+        private const val PREF_ENABLE_TRACKING = "pref_enable_tracking"
+        private const val PREF_PROTECT_HIGHEST = "pref_protect_highest"
+        private const val PREF_BOOKMARK_CHAPTER = "pref_bookmark_chapter_on_read"
+        private const val PREF_RESET_TRACKING_CACHE = "pref_reset_tracking_cache"
+        private const val PREF_POST_ID_CACHE = "pref_post_id_cache"
+        private const val PREF_HIGHEST_CACHE = "pref_highest_tracked_cache"
     }
 
     private class StatusFilter :
@@ -510,4 +788,31 @@ open class MadaraNovel(
             else -> "latest"
         }
     }
+}
+
+/**
+ * Converts an element's HTML into plain text while preserving paragraph
+ * (<p>) and line (<br>) breaks as newlines, instead of Jsoup's text()
+ * which collapses everything into a single line.
+ *
+ * Top-level so standalone Madara-like sources that don't extend
+ * [MadaraNovel] can reuse it too.
+ */
+fun Element.formattedDescription(): String {
+    val breakToken = "__MADARA_BR__"
+    val paragraphToken = "__MADARA_P__"
+    val node = clone()
+    node.select("script, style").remove()
+    node.select("br").forEach { it.after(breakToken) }
+    node.select("p, div, h1, h2, h3, h4, h5, h6, li")
+        // the root element itself can match (e.g. div.summary__content) but has
+        // no parent on the clone, so after() would throw
+        .filter { it !== node }
+        .forEach { it.after(paragraphToken) }
+    return node.text()
+        .replace(' ', ' ')
+        .replace(Regex("""\s*$paragraphToken\s*"""), "\n\n")
+        .replace(Regex("""\s*$breakToken\s*"""), "\n")
+        .replace(Regex("\n{3,}"), "\n\n")
+        .trim()
 }

--- a/src/en/boxnovel/build.gradle
+++ b/src/en/boxnovel/build.gradle
@@ -1,9 +1,9 @@
 ext {
     extName = 'BoxNovel'
     extClass = '.BoxNovel'
-    themePkg = 'readnovelfull'
-    baseUrl = 'https://novlove.com'
-    overrideVersionCode = 1
+    themePkg = 'madaranovel'
+    baseUrl = 'https://novelnice.com'
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/boxnovel/src/eu/kanade/tachiyomi/extension/en/boxnovel/BoxNovel.kt
+++ b/src/en/boxnovel/src/eu/kanade/tachiyomi/extension/en/boxnovel/BoxNovel.kt
@@ -1,142 +1,181 @@
 package eu.kanade.tachiyomi.novelextension.en.boxnovel
 
-import eu.kanade.tachiyomi.multisrc.readnovelfull.ReadNovelFull
+import eu.kanade.tachiyomi.multisrc.madaranovel.MadaraNovel
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 
 class BoxNovel :
-    ReadNovelFull(
+    MadaraNovel(
+        baseUrl = "https://novelnice.com",
         name = "BoxNovel",
-        baseUrl = "https://novlove.com",
         lang = "en",
     ) {
-    override val latestPage = "sort/nov-love-daily-update"
+    override val useNewChapterEndpointDefault = true
+    override val reverseChapterListDefault = true
 
-    // BoxNovel uses path-based filtering instead of query parameters
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        if (query.isNotBlank()) {
-            return super.searchMangaRequest(page, query, filters)
-        }
+        val url = "$baseUrl/page/$page/".toHttpUrl().newBuilder()
+            .addQueryParameter("s", query)
+            .addQueryParameter("post_type", "wp-manga")
 
-        // Handle filters
-        var path = ""
         filters.forEach { filter ->
             when (filter) {
-                is TypeFilter -> {
-                    if (filter.state > 0) {
-                        path = typeOptions[filter.state].second
+                is AuthorFilter -> if (filter.state.isNotBlank()) {
+                    url.addQueryParameter("author", filter.state)
+                }
+
+                is ArtistFilter -> if (filter.state.isNotBlank()) {
+                    url.addQueryParameter("artist", filter.state)
+                }
+
+                is YearFilter -> if (filter.state.isNotBlank()) {
+                    url.addQueryParameter("release", filter.state)
+                }
+
+                is AdultFilter -> {
+                    val value = adultOptions[filter.state].second
+                    if (value.isNotEmpty()) {
+                        url.addQueryParameter("adult", value)
                     }
                 }
 
-                is GenreFilter -> {
-                    if (filter.state > 0) {
-                        path = genreOptions[filter.state].second
+                is OrderByFilter -> {
+                    val value = orderByOptions[filter.state].second
+                    if (value.isNotEmpty()) {
+                        url.addQueryParameter("m_orderby", value)
                     }
                 }
+
+                is GenreConditionFilter -> if (filter.state) {
+                    url.addQueryParameter("op", "1")
+                }
+
+                is StatusFilter ->
+                    filter.state
+                        .filter { it.state }
+                        .forEach { url.addQueryParameter("status[]", it.value) }
+
+                is GenreFilter ->
+                    filter.state
+                        .filter { it.state }
+                        .forEach { url.addQueryParameter("genre[]", it.value) }
 
                 else -> {}
             }
         }
 
-        // Default to popular if no filter selected
-        if (path.isEmpty()) {
-            path = "sort/nov-love-popular"
-        }
-
-        // Add page number
-        val url = if (page > 1) {
-            "$baseUrl/$path?page=$page"
-        } else {
-            "$baseUrl/$path"
-        }
-
-        return GET(url, headers)
+        return GET(url.build(), headers)
     }
 
     override fun getFilterList() = FilterList(
-        Filter.Header("Filters are ignored with text search"),
-        Filter.Separator(),
-        TypeFilter(),
+        AuthorFilter(),
+        ArtistFilter(),
+        YearFilter(),
+        AdultFilter(),
+        OrderByFilter(),
+        GenreConditionFilter(),
+        StatusFilter(),
         GenreFilter(),
     )
 
-    private class TypeFilter :
-        Filter.Select<String>(
-            "Type",
-            typeOptions.map { it.first }.toTypedArray(),
-        )
+    private class AuthorFilter : Filter.Text("Author")
+    private class ArtistFilter : Filter.Text("Artist")
+    private class YearFilter : Filter.Text("Year of Released")
 
-    private class GenreFilter :
-        Filter.Select<String>(
-            "Genre",
-            genreOptions.map { it.first }.toTypedArray(),
-        )
+    private class AdultFilter : Filter.Select<String>("Adult content", adultOptions.map { it.first }.toTypedArray())
+
+    private class OrderByFilter : Filter.Select<String>("Order by", orderByOptions.map { it.first }.toTypedArray())
+
+    private class GenreConditionFilter : Filter.CheckBox("Having all selected genres")
+
+    private class GenreCheckBox(name: String, val value: String) : Filter.CheckBox(name)
+
+    private class StatusFilter : Filter.Group<GenreCheckBox>("Status", statusOptions.map { GenreCheckBox(it.first, it.second) })
+
+    private class GenreFilter : Filter.Group<GenreCheckBox>("Genre", genreOptions.map { GenreCheckBox(it.first, it.second) })
 
     companion object {
-        private val typeOptions = listOf(
+        private val adultOptions = listOf(
             Pair("All", ""),
-            Pair("Hot Novel", "sort/nov-love-hot"),
-            Pair("Completed Novel", "sort/nov-love-complete"),
-            Pair("Most Popular", "sort/nov-love-popular"),
+            Pair("None adult content", "0"),
+            Pair("Only adult content", "1"),
+        )
+
+        private val orderByOptions = listOf(
+            Pair("Relevance", ""),
+            Pair("Latest", "latest"),
+            Pair("A-Z", "alphabet"),
+            Pair("Rating", "rating"),
+            Pair("Trending", "trending"),
+            Pair("Most Views", "views"),
+            Pair("New", "new-manga"),
+        )
+
+        private val statusOptions = listOf(
+            Pair("OnGoing", "on-going"),
+            Pair("Completed", "end"),
+            Pair("Canceled", "canceled"),
+            Pair("On Hold", "on-hold"),
+            Pair("Upcoming", "upcoming"),
         )
 
         private val genreOptions = listOf(
-            Pair("All", ""),
-            Pair("Action", "nov-love-genres/action"),
-            Pair("Adventure", "nov-love-genres/adventure"),
-            Pair("Anime & Comics", "nov-love-genres/anime-&-comics"),
-            Pair("Comedy", "nov-love-genres/comedy"),
-            Pair("Drama", "nov-love-genres/drama"),
-            Pair("Eastern", "nov-love-genres/eastern"),
-            Pair("Fan-fiction", "nov-love-genres/fan-fiction"),
-            Pair("Fanfiction", "nov-love-genres/fanfiction"),
-            Pair("Fantasy", "nov-love-genres/fantasy"),
-            Pair("Game", "nov-love-genres/game"),
-            Pair("Games", "nov-love-genres/games"),
-            Pair("Gender Bender", "nov-love-genres/gender-bender"),
-            Pair("General", "nov-love-genres/general"),
-            Pair("Harem", "nov-love-genres/harem"),
-            Pair("Historical", "nov-love-genres/historical"),
-            Pair("Horror", "nov-love-genres/horror"),
-            Pair("Isekai", "nov-love-genres/isekai"),
-            Pair("Josei", "nov-love-genres/josei"),
-            Pair("LitRPG", "nov-love-genres/litrpg"),
-            Pair("Magic", "nov-love-genres/magic"),
-            Pair("Magical Realism", "nov-love-genres/magical-realism"),
-            Pair("Martial Arts", "nov-love-genres/martial-arts"),
-            Pair("Mature", "nov-love-genres/mature"),
-            Pair("Mecha", "nov-love-genres/mecha"),
-            Pair("Modern Life", "nov-love-genres/modern-life"),
-            Pair("Mystery", "nov-love-genres/mystery"),
-            Pair("Other", "nov-love-genres/other"),
-            Pair("Psychological", "nov-love-genres/psychological"),
-            Pair("Reincarnation", "nov-love-genres/reincarnation"),
-            Pair("Romance", "nov-love-genres/romance"),
-            Pair("School Life", "nov-love-genres/school-life"),
-            Pair("Sci-fi", "nov-love-genres/sci-fi"),
-            Pair("Seinen", "nov-love-genres/seinen"),
-            Pair("Shoujo", "nov-love-genres/shoujo"),
-            Pair("Shoujo Ai", "nov-love-genres/shoujo-ai"),
-            Pair("Shounen", "nov-love-genres/shounen"),
-            Pair("Shounen Ai", "nov-love-genres/shounen-ai"),
-            Pair("Slice of Life", "nov-love-genres/slice-of-life"),
-            Pair("Smut", "nov-love-genres/smut"),
-            Pair("Sports", "nov-love-genres/sports"),
-            Pair("Supernatural", "nov-love-genres/supernatural"),
-            Pair("System", "nov-love-genres/system"),
-            Pair("Thriller", "nov-love-genres/thriller"),
-            Pair("Tragedy", "nov-love-genres/tragedy"),
-            Pair("Urban", "nov-love-genres/urban"),
-            Pair("Urban Life", "nov-love-genres/urban-life"),
-            Pair("Video Games", "nov-love-genres/video-games"),
-            Pair("War", "nov-love-genres/war"),
-            Pair("Wuxia", "nov-love-genres/wuxia"),
-            Pair("Xianxia", "nov-love-genres/xianxia"),
-            Pair("Xuanhuan", "nov-love-genres/xuanhuan"),
-            Pair("Yaoi", "nov-love-genres/yaoi"),
-            Pair("Yuri", "nov-love-genres/yuri"),
+            Pair("Action", "action"),
+            Pair("Adventure", "adventure"),
+            Pair("Anime & Comics", "anime-comics"),
+            Pair("Comedy", "comedy"),
+            Pair("Drama", "drama"),
+            Pair("Eastern", "eastern"),
+            Pair("Fan-fiction", "fan-fiction"),
+            Pair("Fanfiction", "fanfiction"),
+            Pair("Fantasy", "fantasy"),
+            Pair("Game", "game"),
+            Pair("Games", "games"),
+            Pair("Gender Bender", "gender-bender"),
+            Pair("General", "general"),
+            Pair("Harem", "harem"),
+            Pair("Historical", "historical"),
+            Pair("Horror", "horror"),
+            Pair("Isekai", "isekai"),
+            Pair("Josei", "josei"),
+            Pair("LitRPG", "litrpg"),
+            Pair("Magic", "magic"),
+            Pair("Magical Realism", "magical-realism"),
+            Pair("Martial Arts", "martial-arts"),
+            Pair("Mature", "mature"),
+            Pair("Mecha", "mecha"),
+            Pair("Modern Life", "modern-life"),
+            Pair("Mystery", "mystery"),
+            Pair("Other", "other"),
+            Pair("Psychological", "psychological"),
+            Pair("Reincarnation", "reincarnation"),
+            Pair("Romance", "romance"),
+            Pair("School Life", "school-life"),
+            Pair("Sci-fi", "sci-fi"),
+            Pair("Seinen", "seinen"),
+            Pair("Shoujo", "shoujo"),
+            Pair("Shoujo Ai", "shoujo-ai"),
+            Pair("Shounen", "shounen"),
+            Pair("Shounen Ai", "shounen-ai"),
+            Pair("Slice of Life", "slice-of-life"),
+            Pair("Smut", "smut"),
+            Pair("Sports", "sports"),
+            Pair("Supernatural", "supernatural"),
+            Pair("System", "system"),
+            Pair("Thriller", "thriller"),
+            Pair("Tragedy", "tragedy"),
+            Pair("Urban", "urban"),
+            Pair("Urban Life", "urban-life"),
+            Pair("Video Games", "video-games"),
+            Pair("War", "war"),
+            Pair("Wuxia", "wuxia"),
+            Pair("Xianxia", "xianxia"),
+            Pair("Xuanhuan", "xuanhuan"),
+            Pair("Yaoi", "yaoi"),
+            Pair("Yuri", "yuri"),
         )
     }
 }

--- a/src/en/translatino/build.gradle
+++ b/src/en/translatino/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.TranslatinOtaku'
     themePkg = 'madaranovel'
     baseUrl = 'https://translatinotaku.net'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/translatino/src/eu/kanade/tachiyomi/extension/en/translatino/TranslatinOtaku.kt
+++ b/src/en/translatino/src/eu/kanade/tachiyomi/extension/en/translatino/TranslatinOtaku.kt
@@ -1,288 +1,83 @@
 package eu.kanade.tachiyomi.novelextension.en.translatino
 
+import eu.kanade.tachiyomi.multisrc.madaranovel.MadaraNovel
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.source.NovelSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.source.model.MangasPage
-import eu.kanade.tachiyomi.source.model.Page
-import eu.kanade.tachiyomi.source.model.SChapter
-import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.HttpSource
-import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
-import okhttp3.Response
-import org.jsoup.Jsoup
 
 /**
- * TranslatinOtaku / WebNovelTranslations - Madara-based novel site
- * Uses advanced search with GET for page 1, POST admin-ajax.php for subsequent pages
+ * TranslatinOtaku / WebNovelTranslations - Madara-based novel site.
  */
 class TranslatinOtaku :
-    HttpSource(),
-    NovelSource {
-
-    override val name = "Translatin Otaku"
-    override val baseUrl = "https://translatinotaku.net/"
-    override val lang = "en"
-    override val supportsLatest = true
-    override val isNovelSource = true
-
-    override val client = network.cloudflareClient
+    MadaraNovel(
+        baseUrl = "https://translatinotaku.net",
+        name = "Translatin Otaku",
+        lang = "en",
+    ) {
+    override val useNewChapterEndpointDefault = true
 
     override fun headersBuilder() = super.headersBuilder()
         .add("Referer", "$baseUrl/")
 
-    // ======================== Popular ========================
-
-    override fun popularMangaRequest(page: Int): Request = if (page == 1) {
-        GET("$baseUrl/?s=&post_type=wp-manga&m_orderby=trending", headers)
-    } else {
-        buildAjaxRequest(page, "", emptyMap())
-    }
-
-    override fun popularMangaParse(response: Response): MangasPage = if (response.request.url.toString().contains("admin-ajax")) {
-        parseAjaxResponse(response)
-    } else {
-        parseFirstPage(response)
-    }
-
-    // ======================== Latest ========================
-
-    override fun latestUpdatesRequest(page: Int): Request = if (page == 1) {
-        GET("$baseUrl/?s=&post_type=wp-manga&m_orderby=latest", headers)
-    } else {
-        buildAjaxRequest(page, "", emptyMap())
-    }
-
-    override fun latestUpdatesParse(response: Response) = popularMangaParse(response)
-
-    // ======================== Search ========================
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/page/$page/?s=&post_type=wp-manga&m_orderby=trending", headers)
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val params = mutableMapOf<String, String>()
-        val genres = mutableListOf<String>()
-        val statuses = mutableListOf<String>()
-        var genreOp = ""
-        var author = ""
-        var artist = ""
-        var release = ""
-        var adult = ""
+        val urlBuilder = "$baseUrl/page/$page/".toHttpUrl().newBuilder()
+            .addQueryParameter("s", query)
+            .addQueryParameter("post_type", "wp-manga")
 
         filters.forEach { filter ->
             when (filter) {
-                is GenreFilter -> {
-                    filter.state.filter { it.state }.forEach { genres.add(it.id) }
+                is GenreFilter ->
+                    filter.state
+                        .filter { it.state }
+                        .forEach { urlBuilder.addQueryParameter("genre[]", it.id) }
+
+                is GenreConditionFilter -> if (filter.state == 1) {
+                    urlBuilder.addQueryParameter("op", "1")
                 }
 
-                is GenreConditionFilter -> genreOp = if (filter.state == 1) "1" else ""
-
-                is AuthorFilter -> author = filter.state
-
-                is ArtistFilter -> artist = filter.state
-
-                is ReleaseYearFilter -> release = filter.state
-
-                is AdultContentFilter -> adult = filter.toUriPart()
-
-                is StatusFilter -> {
-                    filter.state.filter { it.state }.forEach { statuses.add(it.id) }
+                is AuthorFilter -> if (filter.state.isNotBlank()) {
+                    urlBuilder.addQueryParameter("author", filter.state)
                 }
+
+                is ArtistFilter -> if (filter.state.isNotBlank()) {
+                    urlBuilder.addQueryParameter("artist", filter.state)
+                }
+
+                is ReleaseYearFilter -> if (filter.state.isNotBlank()) {
+                    urlBuilder.addQueryParameter("release", filter.state)
+                }
+
+                is AdultContentFilter -> {
+                    val value = filter.toUriPart()
+                    if (value.isNotEmpty()) urlBuilder.addQueryParameter("adult", value)
+                }
+
+                is StatusGroupFilter ->
+                    filter.state
+                        .filter { it.state }
+                        .forEach { urlBuilder.addQueryParameter("status[]", it.id) }
 
                 else -> {}
             }
         }
 
-        if (page == 1) {
-            val urlBuilder = baseUrl.toHttpUrl().newBuilder()
-            urlBuilder.addQueryParameter("s", query)
-            urlBuilder.addQueryParameter("post_type", "wp-manga")
-            genres.forEach { urlBuilder.addQueryParameter("genre[]", it) }
-            if (genreOp.isNotEmpty()) urlBuilder.addQueryParameter("op", genreOp)
-            if (author.isNotEmpty()) urlBuilder.addQueryParameter("author", author)
-            if (artist.isNotEmpty()) urlBuilder.addQueryParameter("artist", artist)
-            if (release.isNotEmpty()) urlBuilder.addQueryParameter("release", release)
-            if (adult.isNotEmpty()) urlBuilder.addQueryParameter("adult", adult)
-            statuses.forEach { urlBuilder.addQueryParameter("status[]", it) }
-            return GET(urlBuilder.build().toString(), headers)
-        } else {
-            params["s"] = query
-            genres.forEach { params["genre[]"] = it }
-            if (genreOp.isNotEmpty()) params["op"] = genreOp
-            if (author.isNotEmpty()) params["author"] = author
-            if (artist.isNotEmpty()) params["artist"] = artist
-            if (release.isNotEmpty()) params["release"] = release
-            if (adult.isNotEmpty()) params["adult"] = adult
-            statuses.forEachIndexed { i, s -> params["status[$i]"] = s }
-            return buildAjaxRequest(page, query, params)
-        }
-    }
-
-    override fun searchMangaParse(response: Response) = popularMangaParse(response)
-
-    // ======================== Ajax Helpers ========================
-
-    private fun buildAjaxRequest(page: Int, query: String, extraParams: Map<String, String>): Request {
-        val body = FormBody.Builder()
-            .add("action", "madara_load_more")
-            .add("page", (page - 1).toString())
-            .add("template", "madara-core/content/content-search")
-            .add("vars[s]", query)
-            .add("vars[orderby]", "")
-            .add("vars[paged]", "1")
-            .add("vars[template]", "search")
-            .add("vars[meta_query][0][relation]", "AND")
-            .add("vars[meta_query][relation]", "AND")
-            .add("vars[post_type]", "wp-manga")
-            .add("vars[post_status]", "publish")
-            .add("vars[manga_archives_item_layout]", "default")
-
-        extraParams.forEach { (key, value) ->
-            body.add("vars[$key]", value)
-        }
-
-        return POST("$baseUrl/wp-admin/admin-ajax.php", headers, body.build())
-    }
-
-    private fun parseFirstPage(response: Response): MangasPage {
-        val doc = Jsoup.parse(response.body.string())
-        val novels = doc.select(".c-tabs-item__content, .row.c-tabs-item__content").mapNotNull { element ->
-            val link = element.selectFirst(".post-title a, .post-title h3 a") ?: return@mapNotNull null
-            val img = element.selectFirst("img")
-            SManga.create().apply {
-                title = link.text().trim()
-                setUrlWithoutDomain(link.attr("href"))
-                thumbnail_url = img?.let { imgEl ->
-                    val src = imgEl.attr("data-src").ifEmpty {
-                        imgEl.attr("data-lazy-src").ifEmpty {
-                            imgEl.attr("srcset").split(",").firstOrNull()?.trim()?.split(" ")?.firstOrNull()
-                                ?: imgEl.attr("src")
-                        }
-                    }
-                    if (src.contains("placeholder") || src.isBlank()) null else src
-                }
-            }
-        }
-        val hasNext = doc.selectFirst(".nav-previous a, a.nextpostslink, .wp-pagenavi a.nextpostslink") != null ||
-            doc.select(".page-item:not(.active):last-child a").isNotEmpty() ||
-            doc.selectFirst("a.next.page-numbers") != null ||
-            doc.select(".pagination a").any { it.text() == "2" || it.text() == "»" || it.text().contains("Next") } ||
-            novels.size >= 12 // If we got a full page, likely more exist
-        return MangasPage(novels, hasNext)
-    }
-
-    private fun parseAjaxResponse(response: Response): MangasPage {
-        val html = response.body.string()
-        if (html.isBlank() || html == "0") return MangasPage(emptyList(), false)
-
-        val doc = Jsoup.parse(html)
-        val novels = doc.select(".c-tabs-item__content, .row.c-tabs-item__content").mapNotNull { element ->
-            val link = element.selectFirst(".post-title a, .post-title h3 a") ?: return@mapNotNull null
-            val img = element.selectFirst("img")
-            SManga.create().apply {
-                title = link.text().trim()
-                setUrlWithoutDomain(link.attr("href"))
-                thumbnail_url = img?.let { imgEl ->
-                    val src = imgEl.attr("data-src").ifEmpty {
-                        imgEl.attr("data-lazy-src").ifEmpty {
-                            imgEl.attr("srcset").split(",").firstOrNull()?.trim()?.split(" ")?.firstOrNull()
-                                ?: imgEl.attr("src")
-                        }
-                    }
-                    if (src.contains("placeholder") || src.isBlank()) null else src
-                }
-            }
-        }
-        return MangasPage(novels, novels.isNotEmpty())
-    }
-
-    // ======================== Details ========================
-
-    override fun mangaDetailsParse(response: Response): SManga {
-        val doc = Jsoup.parse(response.body.string())
-        return SManga.create().apply {
-            title = doc.selectFirst(".post-title h1")?.text()?.trim() ?: ""
-            thumbnail_url = doc.selectFirst(".summary_image img")?.let {
-                it.attr("data-lazy-src").ifEmpty { it.attr("data-src") }.ifEmpty { it.attr("src") }
-            }
-            description = doc.selectFirst("div.summary__content")?.text()?.trim()
-            author = doc.select(".post-content_item").find { it.selectFirst("h5")?.text()?.contains("Author", ignoreCase = true) == true }?.selectFirst(".summary-content")?.text()?.trim()
-            genre = doc.select(".post-content_item").find { it.selectFirst("h5")?.text()?.contains("Genre", ignoreCase = true) == true }?.select(".summary-content a")?.joinToString(", ") { it.text().trim() }
-            status = doc.select(".post-content_item").find { it.selectFirst("h5")?.text()?.contains("Status", ignoreCase = true) == true }?.selectFirst(".summary-content")?.text()?.let {
-                when {
-                    it.contains("OnGoing", ignoreCase = true) -> SManga.ONGOING
-                    it.contains("Completed", ignoreCase = true) -> SManga.COMPLETED
-                    else -> SManga.UNKNOWN
-                }
-            } ?: SManga.UNKNOWN
-        }
-    }
-
-    // ======================== Chapters ========================
-
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val doc = Jsoup.parse(response.body.string())
-        val mangaUrl = response.request.url.encodedPath
-
-        val body = FormBody.Builder().build()
-        val chapResponse = client.newCall(
-            POST("$baseUrl${mangaUrl}ajax/chapters/", headers, body),
-        ).execute()
-        val html = chapResponse.body.string()
-
-        if (html == "0" || html.isBlank()) return emptyList()
-
-        val chapDoc = Jsoup.parse(html)
-        return chapDoc.select(".wp-manga-chapter").mapNotNull { element ->
-            val link = element.selectFirst("a") ?: return@mapNotNull null
-            SChapter.create().apply {
-                setUrlWithoutDomain(link.attr("href"))
-                name = link.text().trim()
-                date_upload = element.selectFirst(".chapter-release-date")?.text()?.let { parseDate(it) } ?: 0L
-            }
-        }.reversed()
-    }
-
-    private fun parseDate(dateStr: String): Long {
-        if (dateStr.isBlank()) return 0L
-        val number = Regex("\\d+").find(dateStr)?.value?.toIntOrNull() ?: return 0L
-        val calendar = java.util.Calendar.getInstance()
-        when {
-            dateStr.contains("hour", ignoreCase = true) -> calendar.add(java.util.Calendar.HOUR_OF_DAY, -number)
-            dateStr.contains("day", ignoreCase = true) -> calendar.add(java.util.Calendar.DAY_OF_MONTH, -number)
-            dateStr.contains("week", ignoreCase = true) -> calendar.add(java.util.Calendar.WEEK_OF_YEAR, -number)
-            dateStr.contains("month", ignoreCase = true) -> calendar.add(java.util.Calendar.MONTH, -number)
-            dateStr.contains("year", ignoreCase = true) -> calendar.add(java.util.Calendar.YEAR, -number)
-        }
-        return calendar.timeInMillis
-    }
-
-    // ======================== Pages ========================
-
-    override fun pageListParse(response: Response): List<Page> = listOf(Page(0, response.request.url.toString()))
-
-    override fun imageUrlParse(response: Response) = ""
-
-    override suspend fun fetchPageText(page: Page): String {
-        val response = client.newCall(GET(page.url, headers)).execute()
-        val doc = Jsoup.parse(response.body.string())
-        doc.select("div.ads, script, ins, .adsbygoogle, .code-block").remove()
-        return doc.selectFirst(".text-left, .reading-content, .entry-content")?.html() ?: ""
+        return GET(urlBuilder.build().toString(), headers)
     }
 
     // ======================== Filters ========================
 
     override fun getFilterList() = FilterList(
-        Filter.Header("Filters ignored when using text search"),
         GenreFilter(getGenreList()),
         GenreConditionFilter(),
         AuthorFilter(),
         ArtistFilter(),
         ReleaseYearFilter(),
         AdultContentFilter(),
-        StatusFilter(getStatusList()),
+        StatusGroupFilter(getStatusList()),
     )
 
     private class GenreCheckBox(name: String, val id: String) : Filter.CheckBox(name)
@@ -317,7 +112,7 @@ class TranslatinOtaku :
     }
 
     private class StatusCheckBox(name: String, val id: String) : Filter.CheckBox(name)
-    private class StatusFilter(statuses: List<Pair<String, String>>) :
+    private class StatusGroupFilter(statuses: List<Pair<String, String>>) :
         Filter.Group<StatusCheckBox>(
             "Status",
             statuses.map { StatusCheckBox(it.first, it.second) },

--- a/src/en/zetrotranslation/build.gradle
+++ b/src/en/zetrotranslation/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.ZetroTranslation'
     themePkg = 'madaranovel'
     baseUrl = 'https://zetrotranslation.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
     isNovel = true
 }

--- a/src/en/zetrotranslation/src/eu/kanade/tachiyomi/extension/en/zetrotranslation/ZetroTranslation.kt
+++ b/src/en/zetrotranslation/src/eu/kanade/tachiyomi/extension/en/zetrotranslation/ZetroTranslation.kt
@@ -28,6 +28,7 @@ class ZetroTranslation :
         get() = preferences.getBoolean(PREF_EXCLUDE_LOCKED, false)
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        super.setupPreferenceScreen(screen)
         CheckBoxPreference(screen.context).apply {
             key = PREF_EXCLUDE_LOCKED
             title = "Exclude locked chapters"


### PR DESCRIPTION
*   Implement `SourceTracker` in `MadaraNovel` to support syncing reading progress and bookmarks to the user's site account via WordPress AJAX endpoints.
*   Add tracking preferences, including a master switch, highest-chapter sync protection, and an option to update site bookmarks when reading.
*   Improve chapter list parsing by stripping common prefixes (Chapter, Ch., Ep.) and properly extracting chapter numbers.
*   Add a `formattedDescription` extension for `Element` to preserve paragraph and line breaks in novel summaries.
*   Migrate `BoxNovel` from the `readnovelfull` multisrc to `madaranovel` and update its base URL.
*   Refactor `Translatin Otaku` to extend `MadaraNovel` instead of being a standalone implementation.
*   Bump version codes for affected extensions.
closes #53 
Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
