### PR TITLE
feat(Fenrirealm): add URL search support and fix URL format

### DIFF
--- a/src/en/fenrirealm/build.gradle
+++ b/src/en/fenrirealm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Fenrirealm'
     extClass = '.Fenrirealm'
-    extVersionCode = 4
+    extVersionCode = 5
     isNsfw = false
     isNovel = true
 }

--- a/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
+++ b/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
@@ -154,6 +154,17 @@ class Fenrirealm :
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        if (query.startsWith("http") && query.contains("/series/")) {
+            val slug = query.substringAfter("/series/")
+                .substringBefore('?')
+                .substringBefore('#')
+                .trim('/')
+                .substringBefore('/')
+            if (slug.isNotBlank()) {
+                return GET("$apiBaseUrl/series/$slug", headers)
+            }
+        }
+
         val url = "$apiBaseUrl/series".toHttpUrl().newBuilder().apply {
             addQueryParameter("page", page.toString())
             addQueryParameter("per_page", "20")
@@ -200,7 +211,18 @@ class Fenrirealm :
         return GET(url, headers)
     }
 
-    override fun searchMangaParse(response: Response): MangasPage = latestUpdatesParse(response)
+    override fun searchMangaParse(response: Response): MangasPage {
+        val lastSegment = response.request.url.encodedPath.trimEnd('/').substringAfterLast('/')
+        if (lastSegment != "series") {
+            return try {
+                val manga = json.decodeFromString<NovelDto>(response.body.string()).toSManga(baseUrl)
+                MangasPage(listOf(manga), false)
+            } catch (_: Exception) {
+                MangasPage(emptyList(), false)
+            }
+        }
+        return latestUpdatesParse(response)
+    }
 
     override fun getMangaUrl(manga: SManga): String {
         val slug = manga.url.trim('/').substringAfterLast('/')
@@ -208,7 +230,7 @@ class Fenrirealm :
     }
 
     override fun mangaDetailsRequest(manga: SManga): Request {
-        val slug = manga.url.removePrefix("/").removeSuffix("/")
+        val slug = manga.url.removePrefix("/").removeSuffix("/").removePrefix("series/")
         return GET("$apiBaseUrl/series/$slug", headers)
     }
 
@@ -225,7 +247,7 @@ class Fenrirealm :
     }
 
     override fun chapterListRequest(manga: SManga): Request {
-        val slug = manga.url.removePrefix("/").removeSuffix("/")
+        val slug = manga.url.removePrefix("/").removeSuffix("/").removePrefix("series/")
         return GET("$apiBaseUrl/series/$slug/chapters", headers)
     }
 
@@ -336,7 +358,7 @@ class Fenrirealm :
             .orEmpty()
 
         return SManga.create().apply {
-            url = if (searchedSlug.isNotBlank()) "/$searchedSlug" else "/"
+            url = if (searchedSlug.isNotBlank()) "/series/$searchedSlug" else "/"
             title = searchedSlug
                 .substringAfterLast('/')
                 .replace('-', ' ')
@@ -382,7 +404,7 @@ class Fenrirealm :
         @SerialName("global_note") val globalNote: String? = null,
     ) {
         fun toSManga(baseUrl: String): SManga = SManga.create().apply {
-            url = "/$slug"
+            url = "/series/$slug"
             this.title = this@NovelDto.title
             thumbnail_url = if (!cover.isNullOrEmpty()) {
                 if (cover.startsWith("http")) cover else "$baseUrl/$cover"

--- a/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
+++ b/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
@@ -309,19 +309,16 @@ class Fenrirealm :
             ?: doc.selectFirst("div[role=region][id^=reader-area]")
             ?: return ""
 
-        val result = StringBuilder()
-
-        for (element in readerArea.children()) {
-            val html = element.outerHtml()
-            if (html.contains("What do you think", ignoreCase = true) ||
-                html.contains("comment", ignoreCase = true)
-            ) {
-                break
-            }
-            result.append(html)
+        // Strip real comment/reaction sections structurally. Never match on prose
+        // text: a chapter sentence containing the word "comment" used to cut the
+        // rest of the chapter off.
+        readerArea.select("#comments").forEach { it.remove() }
+        readerArea.select("h3:containsOwn(What do you think)").forEach { heading ->
+            val section = heading.parents().firstOrNull { it.parent() === readerArea }
+            (section ?: heading).remove()
         }
 
-        return result.toString()
+        return readerArea.children().joinToString("") { it.outerHtml() }
     }
 
     override fun getFilterList(): FilterList = FilterList(


### PR DESCRIPTION
- Add support for searching by series URL in `searchMangaRequest` by extracting the slug.
- Update `searchMangaParse` to handle single-novel API responses from URL searches.
- Standardize manga internal URLs to include the `/series/` prefix and update request handlers accordingly.
- replaced bad regex that caused some chapters to be cut off 
closes #62 


Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
