### PR TITLE
fictioneer: update pagination and reverse chapter list

### DIFF
--- a/lib-multisrc/fictioneer/build.gradle.kts
+++ b/lib-multisrc/fictioneer/build.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 1
+baseVersionCode = 2

--- a/lib-multisrc/fictioneer/src/eu/kanade/tachiyomi/multisrc/fictioneer/Fictioneer.kt
+++ b/lib-multisrc/fictioneer/src/eu/kanade/tachiyomi/multisrc/fictioneer/Fictioneer.kt
@@ -48,7 +48,7 @@ open class Fictioneer(
                 thumbnail_url = element.selectFirst("a.cell-img:has(img)")?.attr("href")
             }
         }
-        val hasNext = doc.selectFirst(".page-numbers .next") != null
+        val hasNext = doc.selectFirst("a.next.page-numbers") != null
         return MangasPage(novels, hasNext)
     }
 
@@ -116,7 +116,7 @@ open class Fictioneer(
                     this.url = url.replace(baseUrl, "").trimEnd('/')
                     name = linkEl.text().trim()
                 }
-            }
+            }.reversed()
     }
 
     // -- Pages --


### PR DESCRIPTION
* Update the CSS selector for the next page link to "a.next.page-numbers".
* Reverse the parsed chapter list to ensure correct ordering.


Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
