### PR TITLE
feat(novelhall): fix chapter order and improve description parsing

### DIFF
--- a/src/en/novelhall/build.gradle
+++ b/src/en/novelhall/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'NovelHall'
     extClass = '.NovelHall'
-    extVersionCode = 1
+    extVersionCode = 2
     isNovel = true
 }
 

--- a/src/en/novelhall/src/eu/kanade/tachiyomi/extension/en/novelhall/NovelHall.kt
+++ b/src/en/novelhall/src/eu/kanade/tachiyomi/extension/en/novelhall/NovelHall.kt
@@ -163,7 +163,19 @@ class NovelHall :
 
             thumbnail_url = document.selectFirst("meta[property=og:image]")?.attr("content")
 
-            description = document.selectFirst(".intro")?.text()?.trim()
+            // The full untruncated synopsis lives in the hidden js-close-wrap span
+            description = (
+                document.selectFirst("span.js-close-wrap")
+                    ?: document.selectFirst(".intro")
+                )?.let { el ->
+                el.select("br").forEach { it.after("\\n") }
+                el.select("p").forEach { it.after("\\n\\n") }
+                el.text()
+                    .replace("\\n", "\n")
+                    .replace(Regex(" *\n *"), "\n")
+                    .replace(Regex("\n{3,}"), "\n\n")
+                    .trim()
+            }
 
             // Parse author - remove "Author：" prefix
             val totalSection = document.selectFirst(".total")
@@ -209,7 +221,7 @@ class NovelHall :
 
         // Chapters on NovelHall are in ascending order (oldest first)
         // Return in descending order (newest first) for consistency
-        return chapters
+        return chapters.reversed()
     }
 
     // ======================== Pages ========================


### PR DESCRIPTION
Reverse the chapter list to provide descending order and update description parsing to fetch the full synopsis from the hidden `span.js-close-wrap` element. Improve synopsis formatting by handling line breaks and cleaning up whitespace.

Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
