### PR TITLE
fix(WuxiaClick): use baseUrl for manga and chapter URLs

### DIFF
--- a/src/en/wuxiaclick/build.gradle
+++ b/src/en/wuxiaclick/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'WuxiaClick'
     extClass = '.WuxiaClick'
-    extVersionCode = 2
+    extVersionCode = 3
     isNovel = true
 }
 

--- a/src/en/wuxiaclick/src/eu/kanade/tachiyomi/extension/all/wuxiaclick/WuxiaClick.kt
+++ b/src/en/wuxiaclick/src/eu/kanade/tachiyomi/extension/all/wuxiaclick/WuxiaClick.kt
@@ -335,8 +335,10 @@ class WuxiaClick :
 
     override fun getMangaUrl(manga: SManga): String {
         val slug = extractNovelSlug(manga.url)
-        return "https://wuxiaworld.eu/novel/$slug"
+        return "$baseUrl/novel/$slug"
     }
+
+    override fun getChapterUrl(chapter: SChapter): String = baseUrl + chapter.url
 
     // ======================== Details ========================
 


### PR DESCRIPTION
* Update `getMangaUrl` to use the defined `baseUrl` instead of a hardcoded string.
* Implement `getChapterUrl` to provide full URLs for chapters.

Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
