### PR TITLE
fix(brightnovels): handle 409 Conflict for stale Inertia versions

### DIFF
--- a/src/en/brightnovels/build.gradle
+++ b/src/en/brightnovels/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bright Novels'
     extClass = '.BrightNovels'
-    extVersionCode = 2
+    extVersionCode = 3
     isNovel = true
 }
 

--- a/src/en/brightnovels/src/eu/kanade/tachiyomi/extension/en/brightnovels/BrightNovels.kt
+++ b/src/en/brightnovels/src/eu/kanade/tachiyomi/extension/en/brightnovels/BrightNovels.kt
@@ -51,7 +51,30 @@ class BrightNovels :
         isLenient = true
     }
 
-    override val client = network.cloudflareClient
+    override val client = network.cloudflareClient.newBuilder()
+        .addInterceptor { chain ->
+            val request = chain.request()
+            val response = chain.proceed(request)
+
+            // Inertia returns 409 Conflict when the cached asset version is stale
+            // (site got redeployed). Drop the stale version and retry as a plain
+            // HTML request.
+            if (response.code == 409 && request.header("X-Inertia") != null) {
+                response.close()
+                preferences.edit().remove(PREF_INERTIA_VERSION).apply()
+                val htmlRequest = request.newBuilder()
+                    .removeHeader("X-Inertia")
+                    .removeHeader("X-Inertia-Version")
+                    .removeHeader("X-Inertia-Partial-Component")
+                    .removeHeader("X-Inertia-Partial-Data")
+                    .removeHeader("X-Requested-With")
+                    .build()
+                chain.proceed(htmlRequest)
+            } else {
+                response
+            }
+        }
+        .build()
 
     private val preferences: SharedPreferences by lazy {
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)


### PR DESCRIPTION
Add an interceptor to catch 409 Conflict responses on Inertia requests, which occurs when cached asset versions are stale. The interceptor clears the cached version preference and retries the request as plain HTML to ensure successful data retrieval after site redeployments.

Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
