### PR TITLE
Use Release version in PR tests

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -36,7 +36,7 @@ jobs:
       - id: generate-matrices
         name: Generate build matrices
         run: |
-          python ./.github/scripts/generate-build-matrices.py origin/main Debug
+          python ./.github/scripts/generate-build-matrices.py origin/main Release
 
   build:
     name: Build extensions (${{ matrix.chunk.number }})


### PR DESCRIPTION
Using debug doesn't seem to properly catch some issues when libs are changed