### PR TITLE
RefreshContext & ChapterUtils lib

### DIFF
--- a/lib-multisrc/madaranovel/build.gradle.kts
+++ b/lib-multisrc/madaranovel/build.gradle.kts
@@ -2,4 +2,8 @@ plugins {
     id("lib-multisrc")
 }
 
-baseVersionCode = 2
+baseVersionCode = 3
+
+dependencies {
+    implementation(project(":lib:chapterutils"))
+}

--- a/lib-multisrc/madaranovel/src/eu/kanade/tachiyomi/multisrc/madaranovel/MadaraNovel.kt
+++ b/lib-multisrc/madaranovel/src/eu/kanade/tachiyomi/multisrc/madaranovel/MadaraNovel.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.multisrc.madaranovel
 
 import android.content.SharedPreferences
+import android.util.Log
 import androidx.preference.PreferenceScreen
 import androidx.preference.SwitchPreferenceCompat
 import eu.kanade.tachiyomi.network.GET
@@ -12,9 +13,11 @@ import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.lib.chapterutils.shouldReturnExisting
 import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody
@@ -290,6 +293,27 @@ open class MadaraNovel(
 
     override fun chapterListRequest(manga: SManga): Request = GET(baseUrl + manga.url, headers)
 
+    override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+        val response = client.newCall(chapterListRequest(manga)).execute()
+        val doc = response.asJsoup()
+        val mangaUrl = response.request.url.encodedPath
+
+        val postId = extractPostId(doc)
+        postId?.let { cachePostId(mangaUrl, it) }
+
+        val siteTotal = extractChapterCount(doc)
+        Log.d(TAG, "getChapterList: url=$mangaUrl existing=${context.existingChapters.size} siteTotal=$siteTotal")
+
+        if (shouldReturnExisting(context.existingChapters.size, siteTotal)) {
+            Log.d(TAG, "getChapterList: count unchanged — returning existing")
+            return context.existingChapters
+        }
+
+        val html = fetchChaptersHtml(mangaUrl, postId, response.request.url.toString())
+        val chapters = parseChaptersFromHtml(html)
+        return if (reverseChapterList) chapters else chapters.reversed()
+    }
+
     override fun chapterListParse(response: Response): List<SChapter> {
         val doc = response.asJsoup()
         val mangaUrl = response.request.url.encodedPath
@@ -298,85 +322,97 @@ open class MadaraNovel(
         val postId = extractPostId(doc)
         postId?.let { cachePostId(mangaUrl, it) }
 
+        val html = fetchChaptersHtml(mangaUrl, postId, response.request.url.toString())
+        val chapters = parseChaptersFromHtml(html)
+        return if (reverseChapterList) chapters else chapters.reversed()
+    }
+
+    /**
+     * Extracts the chapter count shown on the novel detail page.
+     * Override in subclasses for sites with non-English or non-standard labels.
+     */
+    protected open fun extractChapterCount(doc: Document): Int {
+        // Primary: look for a post-content_item whose h5 label is "Chapters" (or "Chapter")
+        val labeled = doc.select(".post-content_item")
+            .find { item ->
+                val h5 = item.selectFirst("h5")?.text()?.trim() ?: return@find false
+                h5.equals("Chapters", ignoreCase = true) || h5.equals("Chapter", ignoreCase = true)
+            }
+            ?.selectFirst(".summary-content")
+            ?.text()?.trim()?.toIntOrNull()
+        if (labeled != null && labeled > 0) return labeled
+
+        // Fallback: any summary-content whose trimmed text is a pure integer (works for
+        // non-English sites where the label differs)
+        return doc.select(".post-content_item .summary-content")
+            .mapNotNull { it.text().trim().toIntOrNull() }
+            .firstOrNull { it > 0 } ?: 0
+    }
+
+    private fun fetchChaptersHtml(mangaUrl: String, postId: String?, referer: String): String = if (useNewChapterEndpoint) {
+        val emptyBody = FormBody.Builder().build()
+        val newHeaders = headersBuilder().set("Referer", referer).build()
+        client.newCall(POST("$baseUrl${mangaUrl}ajax/chapters/", newHeaders, emptyBody))
+            .execute().body.string()
+    } else {
+        val formBody = FormBody.Builder()
+            .add("action", "manga_get_chapters")
+            .add("manga", postId ?: "")
+            .build()
+        client.newCall(POST("$baseUrl/wp-admin/admin-ajax.php", headers, formBody))
+            .execute().body.string()
+    }
+
+    private fun parseChaptersFromHtml(html: String): List<SChapter> {
+        if (html == "0") return emptyList()
+        val chapDoc = Jsoup.parse(html)
+        val totalChaps = chapDoc.select(".wp-manga-chapter").size
         val chapters = mutableListOf<SChapter>()
-        var html: String
 
-        if (useNewChapterEndpoint) {
-            val emptyBody = FormBody.Builder().build()
-            val newHeaders = headersBuilder()
-                .set("Referer", response.request.url.toString())
-                .build()
-            val chapResponse = client.newCall(
-                POST("$baseUrl${mangaUrl}ajax/chapters/", newHeaders, emptyBody),
-            ).execute()
-            html = chapResponse.body.string()
-        } else {
-            val formBody = FormBody.Builder()
-                .add("action", "manga_get_chapters")
-                .add("manga", postId ?: "")
-                .build()
+        chapDoc.select(".wp-manga-chapter").forEachIndexed { index, element ->
+            try {
+                val rawName = element.selectFirst("a")?.text()?.trim() ?: return@forEachIndexed
+                val isLocked = element.className().contains("premium-block")
 
-            val chapResponse = client.newCall(
-                POST("$baseUrl/wp-admin/admin-ajax.php", headers, formBody),
-            ).execute()
-            html = chapResponse.body.string()
-        }
+                // The app shows the chapter number separately from the title,
+                // so strip "Chapter 12 - " style prefixes from the displayed name
+                val numberMatch = chapterPrefixRegex.find(rawName)
+                    ?: numberSeparatorRegex.find(rawName)
+                val parsedNumber = numberMatch?.groupValues?.get(1)?.toFloatOrNull()
+                var chapterName = numberMatch?.let { rawName.removeRange(it.range).trim() }
+                    ?.ifEmpty { null }
+                    ?: rawName
 
-        if (html != "0") {
-            val chapDoc = Jsoup.parse(html)
-            val totalChaps = chapDoc.select(".wp-manga-chapter").size
+                if (isLocked) chapterName = "🔒 $chapterName"
 
-            chapDoc.select(".wp-manga-chapter").forEachIndexed { index, element ->
-                try {
-                    val rawName = element.selectFirst("a")?.text()?.trim() ?: return@forEachIndexed
-                    val isLocked = element.className().contains("premium-block")
+                val releaseDate = element.selectFirst(".chapter-release-date")?.text()?.trim() ?: ""
+                val chapterUrl = element.selectFirst("a")?.attr("href") ?: return@forEachIndexed
 
-                    // The app shows the chapter number separately from the title,
-                    // so strip "Chapter 12 - " style prefixes from the displayed name
-                    val numberMatch = chapterPrefixRegex.find(rawName)
-                        ?: numberSeparatorRegex.find(rawName)
-                    val parsedNumber = numberMatch?.groupValues?.get(1)?.toFloatOrNull()
-                    var chapterName = numberMatch?.let { rawName.removeRange(it.range).trim() }
-                        ?.ifEmpty { null }
-                        ?: rawName
-
-                    if (isLocked) {
-                        chapterName = "🔒 $chapterName"
-                    }
-
-                    val releaseDate = element.selectFirst(".chapter-release-date")?.text()?.trim() ?: ""
-                    val chapterUrl = element.selectFirst("a")?.attr("href") ?: return@forEachIndexed
-
-                    if (chapterUrl != "#") {
-                        // Ensure URL is relative path
-                        val relativeChapterUrl = when {
-                            chapterUrl.startsWith(baseUrl) -> chapterUrl.removePrefix(baseUrl)
-
-                            chapterUrl.startsWith("http://") || chapterUrl.startsWith("https://") -> {
-                                try {
-                                    java.net.URI(chapterUrl).path
-                                } catch (e: Exception) {
-                                    chapterUrl
-                                }
+                if (chapterUrl != "#") {
+                    val relativeChapterUrl = when {
+                        chapterUrl.startsWith(baseUrl) -> chapterUrl.removePrefix(baseUrl)
+                        chapterUrl.startsWith("http://") || chapterUrl.startsWith("https://") -> {
+                            try {
+                                java.net.URI(chapterUrl).path
+                            } catch (e: Exception) {
+                                chapterUrl
                             }
-
-                            chapterUrl.startsWith("/") -> chapterUrl
-
-                            else -> "/$chapterUrl"
                         }
-
-                        chapters.add(
-                            SChapter.create().apply {
-                                url = relativeChapterUrl
-                                name = chapterName
-                                date_upload = parseDate(releaseDate)
-                                chapter_number = parsedNumber ?: (totalChaps - index).toFloat()
-                            },
-                        )
+                        chapterUrl.startsWith("/") -> chapterUrl
+                        else -> "/$chapterUrl"
                     }
-                } catch (e: Exception) {
-                    // Skip problematic chapters
+
+                    chapters.add(
+                        SChapter.create().apply {
+                            url = relativeChapterUrl
+                            name = chapterName
+                            date_upload = parseDate(releaseDate)
+                            chapter_number = parsedNumber ?: (totalChaps - index).toFloat()
+                        },
+                    )
                 }
+            } catch (e: Exception) {
+                // Skip problematic chapters
             }
         }
 
@@ -751,6 +787,7 @@ open class MadaraNovel(
     }
 
     companion object {
+        private const val TAG = "MadaraNovel"
         private const val USE_NEW_CHAPTER_ENDPOINT_PREF = "pref_use_new_chapter_endpoint"
         private const val PREF_REVERSE_CHAPTERS = "pref_reverse_chapters"
         private const val PREF_RAW_HTML = "pref_raw_html"

--- a/lib/chapterutils/build.gradle.kts
+++ b/lib/chapterutils/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("lib-android")
+}

--- a/lib/chapterutils/src/keiyoushi/lib/chapterutils/ChapterUtils.kt
+++ b/lib/chapterutils/src/keiyoushi/lib/chapterutils/ChapterUtils.kt
@@ -1,0 +1,174 @@
+package keiyoushi.lib.chapterutils
+
+import eu.kanade.tachiyomi.source.model.RefreshContext
+import eu.kanade.tachiyomi.source.model.SChapter
+import org.jsoup.nodes.Document
+
+// ── High-level entry point ────────────────────────────────────────────────────
+
+/**
+ * Fetches a paginated chapter list with RefreshContext optimisations.
+ *
+ * The caller supplies [fetchPage], a lambda that takes a 1-based page number and returns
+ * the chapters on that page plus whether a next page exists.  URL construction is entirely
+ * the caller's responsibility, so any URL scheme (query param, path segment, etc.) works.
+ *
+ * Behaviour:
+ * - Returns [context].existingChapters immediately when [siteTotal] confirms nothing changed.
+ * - Falls back to a full fetch when [context].existingChapters is empty.
+ * - Otherwise probes the estimated start page, detects the real page size, then fetches only
+ *   the pages that could contain new chapters and prepends the known-good existing chapters.
+ *
+ * @param siteTotal  Chapter count reported by the site (0 or negative = unknown, skips early exit).
+ * @param assumedPageSize  Initial guess for chapters-per-page used before the probe.
+ * @param fetchPage  Lambda `(pageNumber) -> Pair<chapters, hasNextPage>`.
+ * @param sortChapters  Post-processing sort applied to the final list; defaults to chapter-number order.
+ */
+suspend fun paginatedChapterList(
+    context: RefreshContext,
+    siteTotal: Int,
+    assumedPageSize: Int = 100,
+    fetchPage: suspend (page: Int) -> Pair<List<SChapter>, Boolean>,
+    sortChapters: (List<SChapter>) -> List<SChapter> = ::sortByChapterNumber,
+): List<SChapter> {
+    val existing = context.existingChapters
+    val existingCount = existing.size
+
+    if (shouldReturnExisting(existingCount, siteTotal)) {
+        return existing
+    }
+
+    if (existingCount == 0) {
+        return sortChapters(fetchAll(fetchPage))
+    }
+
+    val estimatedStart = incrementalStartPage(existingCount, assumedPageSize)
+    val (probeChapters, probeHasNext) = fetchPage(estimatedStart)
+
+    val pageSize = detectPageSize(probeChapters, probeHasNext, estimatedStart, assumedPageSize)
+    val startPage = incrementalStartPage(existingCount, pageSize)
+    val keepCount = (startPage - 1) * pageSize
+
+    val freshChapters: List<SChapter>
+    if (startPage != estimatedStart) {
+        freshChapters = sortChapters(fetchAll(fetchPage, startPage))
+    } else {
+        val collected = probeChapters.toMutableList()
+        if (probeHasNext) {
+            var page = estimatedStart + 1
+            while (true) {
+                val (pageChapters, hasNext) = fetchPage(page)
+                collected += pageChapters
+                if (!hasNext) break
+                page++
+            }
+        }
+        freshChapters = sortChapters(collected)
+    }
+
+    return mergeChapters(existing, freshChapters, keepCount)
+}
+
+// ── Low-level building blocks ─────────────────────────────────────────────────
+
+/**
+ * Returns true when the existing chapter count exactly matches the site total,
+ * meaning no fetch is needed.  Both values must be positive for this to fire.
+ */
+fun shouldReturnExisting(existingCount: Int, siteTotal: Int): Boolean = existingCount > 0 && siteTotal > 0 && existingCount == siteTotal
+
+/**
+ * Calculates the 1-based page number where an incremental fetch should begin,
+ * given that we already have [existingCount] chapters stored at [pageSize] per page.
+ */
+fun incrementalStartPage(existingCount: Int, pageSize: Int): Int = ((existingCount - 1) / pageSize) + 1
+
+/**
+ * Infers the real page size from a probe page.
+ *
+ * The inference is only reliable when the probe page is a full middle page — i.e. it has a
+ * next page AND is not page 1.  The last page is always partial, and page 1 could be the
+ * only page.  Returns [assumed] in all other cases.
+ */
+fun detectPageSize(
+    probeChapters: List<SChapter>,
+    probeHasNext: Boolean,
+    probePage: Int,
+    assumed: Int,
+): Int = if (probeHasNext && probePage > 1 && probeChapters.isNotEmpty()) {
+    probeChapters.size
+} else {
+    assumed
+}
+
+/**
+ * Merges existing (newest-first as stored) chapters with freshly fetched chapters.
+ *
+ * [keepCount] is the number of existing chapters to carry forward.  The oldest [keepCount]
+ * entries are sliced from [existing] (which is newest-first, so takeLast), reversed to
+ * ascending order, then prepended to [fresh].
+ *
+ * Duplicate URLs between the two lists are harmless — the caller's deduplication layer
+ * (SyncChaptersWithSource) discards them by URL.
+ */
+fun mergeChapters(
+    existing: List<SChapter>,
+    fresh: List<SChapter>,
+    keepCount: Int,
+): List<SChapter> {
+    if (keepCount <= 0) return fresh
+    val keptOldestFirst = existing.takeLast(keepCount).reversed()
+    return keptOldestFirst + fresh
+}
+
+/**
+ * Sorts chapters by the numeric value embedded in their name.
+ *
+ * Matches "chapter N", "ch N", "ch. N" (case-insensitive).  Chapters without a recognisable
+ * number sort to the end (Double.MAX_VALUE).
+ */
+fun sortByChapterNumber(chapters: List<SChapter>): List<SChapter> = chapters.sortedWith(
+    compareBy { chapter ->
+        CHAPTER_NUMBER_REGEX.find(chapter.name)?.groupValues?.get(1)?.toDoubleOrNull()
+            ?: Double.MAX_VALUE
+    },
+)
+
+/**
+ * Returns true if [doc] contains the common pagination selectors for a "next page" link.
+ * Covers Bootstrap-style, rel="next", and aria-label variants seen across extensions.
+ */
+fun standardHasNextPage(doc: Document): Boolean = doc.selectFirst("""a[rel="next"]""") != null ||
+    doc.selectFirst(".pagination li.active + li:not(.disabled) a") != null ||
+    doc.selectFirst("""a.page-link[aria-label*="Next"]""") != null ||
+    doc.selectFirst("""nav[aria-label*="Pagination"] a[rel="next"]""") != null
+
+/**
+ * Throws an [Exception] prompting the user to open a WebView if the document looks like a
+ * Cloudflare challenge page.
+ */
+fun checkCloudflare(doc: Document) {
+    if (doc.title().contains("Cloudflare", ignoreCase = true)) {
+        throw Exception("Cloudflare challenge detected. Please open in WebView.")
+    }
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+private val CHAPTER_NUMBER_REGEX =
+    Regex("""(?:chapter|ch\.?)\s*(\d+(?:\.\d+)?)""", RegexOption.IGNORE_CASE)
+
+private suspend fun fetchAll(
+    fetchPage: suspend (page: Int) -> Pair<List<SChapter>, Boolean>,
+    startPage: Int = 1,
+): List<SChapter> {
+    val all = mutableListOf<SChapter>()
+    var page = startPage
+    while (true) {
+        val (chapters, hasNext) = fetchPage(page)
+        all += chapters
+        if (!hasNext) break
+        page++
+    }
+    return all
+}

--- a/src/en/lightnovelworld/build.gradle
+++ b/src/en/lightnovelworld/build.gradle
@@ -1,8 +1,12 @@
 ext {
     extName = 'Light Novel World'
     extClass = '.LightNovelWorld'
-    extVersionCode = 1
+    extVersionCode = 2
     isNovel = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:chapterutils"))
+}

--- a/src/en/lightnovelworld/src/eu/kanade/tachiyomi/extension/en/lightnovelworld/LightNovelWorld.kt
+++ b/src/en/lightnovelworld/src/eu/kanade/tachiyomi/extension/en/lightnovelworld/LightNovelWorld.kt
@@ -1,21 +1,21 @@
 package eu.kanade.tachiyomi.novelextension.en.lightnovelworld
 
 import android.app.Application
-import androidx.preference.PreferenceScreen
-import androidx.preference.SwitchPreferenceCompat
+import android.util.Log
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.NovelSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.lib.chapterutils.paginatedChapterList
+import keiyoushi.lib.chapterutils.shouldReturnExisting
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
@@ -27,13 +27,11 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
 import java.io.File
-import java.security.MessageDigest
 import java.util.Calendar
 
 class LightNovelWorld :
     HttpSource(),
-    NovelSource,
-    ConfigurableSource {
+    NovelSource {
 
     override val name = "Light Novel World"
     override val baseUrl = "https://lightnovelworld.org"
@@ -45,61 +43,19 @@ class LightNovelWorld :
 
     override val isNovelSource = true
 
+    init {
+        migrateDeleteLegacyChapterCache()
+    }
+
+    private fun migrateDeleteLegacyChapterCache() {
+        val legacyDir = File(Injekt.get<Application>().cacheDir, "lightnovelworld_chapters")
+        if (legacyDir.exists()) {
+            val deleted = legacyDir.deleteRecursively()
+            Log.d(TAG, "migration: deleted legacy chapter cache dir (success=$deleted)")
+        }
+    }
+
     override fun imageUrlParse(response: Response): String = ""
-
-    // ======================== Pagination Caching ========================
-
-    @Serializable
-    data class PaginationState(
-        val lastChapterTotal: Int = 0,
-        val lastUpdated: Long = 0L,
-        val cachedChapters: List<CachedChapter> = emptyList(),
-    )
-
-    @Serializable
-    data class CachedChapter(
-        val name: String,
-        val url: String,
-        val dateUpload: Long = 0L,
-        val chapterNumber: Float = -1f,
-    )
-
-    private val cacheDir: File by lazy {
-        val dir = File(Injekt.get<Application>().cacheDir, "lightnovelworld_chapters")
-        dir.mkdirs()
-        dir
-    }
-
-    private val cacheLock = Any()
-
-    private fun getCacheFile(novelPath: String): File {
-        val md5 = MessageDigest.getInstance("MD5")
-            .digest(novelPath.toByteArray())
-            .joinToString("") { "%02x".format(it) }
-        return File(cacheDir, "$md5.json")
-    }
-
-    private fun loadPaginationState(novelPath: String): PaginationState? = synchronized(cacheLock) {
-        val file = getCacheFile(novelPath)
-        if (!file.exists()) return@synchronized null
-        try {
-            json.decodeFromString<PaginationState>(file.readText())
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    private fun savePaginationState(novelPath: String, state: PaginationState) = synchronized(cacheLock) {
-        try {
-            getCacheFile(novelPath).writeText(json.encodeToString(state))
-        } catch (_: Exception) {}
-    }
-
-    private fun clearAllChapterCache() {
-        synchronized(cacheLock) {
-            cacheDir.listFiles()?.forEach { it.delete() }
-        }
-    }
 
     private fun String?.toAbsoluteUrl(): String? = when {
         this.isNullOrEmpty() -> null
@@ -304,74 +260,51 @@ class LightNovelWorld :
         return GET("$baseUrl$path/chapters/", headers)
     }
 
+    override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+        val response = client.newCall(chapterListRequest(manga)).execute()
+        val page1Doc = Jsoup.parse(response.body.string())
+        val basePath = response.request.url.encodedPath
+
+        val totalPages = page1Doc.select("#pageSelect option").size.coerceAtLeast(1)
+        val currentTotal = Regex("""A total of (\d+) chapters""")
+            .find(page1Doc.selectFirst(".chapters-description")?.text().orEmpty())
+            ?.groupValues?.get(1)?.toIntOrNull() ?: 0
+
+        Log.d(TAG, "getChapterList: url=$basePath existing=${context.existingChapters.size} siteTotal=$currentTotal totalPages=$totalPages")
+
+        if (shouldReturnExisting(context.existingChapters.size, currentTotal)) {
+            Log.d(TAG, "getChapterList: count unchanged — returning existing")
+            return context.existingChapters
+        }
+
+        return paginatedChapterList(
+            context = context,
+            siteTotal = currentTotal,
+            assumedPageSize = CHAPTERS_PER_PAGE,
+            fetchPage = { page ->
+                val doc = if (page == 1) {
+                    page1Doc
+                } else {
+                    val pageResponse = client.newCall(GET("$baseUrl$basePath?page=$page", headers)).execute()
+                    Jsoup.parse(pageResponse.body.string())
+                }
+                Pair(parseChapterPage(doc), page < totalPages)
+            },
+            sortChapters = { it },
+        ).reversed()
+    }
+
+    // Fallback path for when getChapterList is not used; performs a full fetch with no optimisation.
     override fun chapterListParse(response: Response): List<SChapter> {
         val doc = Jsoup.parse(response.body.string())
         val basePath = response.request.url.encodedPath
-
-        // Total pages from the page selector ("Page X of N")
         val totalPages = doc.select("#pageSelect option").size.coerceAtLeast(1)
-
-        // Current chapter total from "A total of N chapters" text
-        val currentTotal = Regex("""A total of (\d+) chapters""")
-            .find(doc.selectFirst(".chapters-description")?.text().orEmpty())
-            ?.groupValues?.get(1)?.toIntOrNull() ?: 0
-
-        val cached = loadPaginationState(basePath)
-
-        // Cache hit: total unchanged, return cached chapters without refetching pages
-        if (cached != null && currentTotal > 0 &&
-            cached.lastChapterTotal == currentTotal &&
-            cached.cachedChapters.isNotEmpty()
-        ) {
-            return cached.cachedChapters.map { it.toSChapter() }.reversed()
+        val chapters = parseChapterPage(doc).toMutableList()
+        for (page in 2..totalPages) {
+            val pageResponse = client.newCall(GET("$baseUrl$basePath?page=$page", headers)).execute()
+            chapters += parseChapterPage(Jsoup.parse(pageResponse.body.string()))
         }
-
-        val chapters = mutableListOf<SChapter>()
-        var startPage = 1
-
-        // Incremental fetch: total grew → keep fully-cached pages (fixed 50/page),
-        // refetch only the last partial page and anything after it
-        if (cached != null && currentTotal > cached.lastChapterTotal && cached.cachedChapters.isNotEmpty()) {
-            val fullPages = cached.cachedChapters.size / CHAPTERS_PER_PAGE
-            if (fullPages > 0) {
-                chapters += cached.cachedChapters.take(fullPages * CHAPTERS_PER_PAGE).map { it.toSChapter() }
-                startPage = fullPages + 1
-            }
-        }
-
-        for (page in startPage..totalPages) {
-            val pageDoc = if (page == 1) {
-                doc
-            } else {
-                val pageResponse = client.newCall(GET("$baseUrl$basePath?page=$page", headers)).execute()
-                Jsoup.parse(pageResponse.body.string())
-            }
-            chapters += parseChapterPage(pageDoc)
-        }
-
-        savePaginationState(
-            basePath,
-            PaginationState(
-                lastChapterTotal = if (currentTotal > 0) currentTotal else chapters.size,
-                lastUpdated = System.currentTimeMillis(),
-                cachedChapters = chapters.map {
-                    CachedChapter(it.name, it.url, it.date_upload, it.chapter_number)
-                },
-            ),
-        )
-
-        // Site lists chapters ascending; app expects newest first
         return chapters.reversed()
-    }
-
-    private fun CachedChapter.toSChapter(): SChapter {
-        val cached = this
-        return SChapter.create().apply {
-            name = cached.name
-            url = cached.url
-            date_upload = cached.dateUpload
-            chapter_number = cached.chapterNumber
-        }
     }
 
     private fun parseChapterPage(doc: Document): List<SChapter> {
@@ -395,7 +328,7 @@ class LightNovelWorld :
 
     private fun parseRelativeDate(dateText: String): Long {
         // Normalize NBSP and other whitespace
-        val text = dateText.replace('\u00A0', ' ').trim().lowercase()
+        val text = dateText.replace(' ', ' ').trim().lowercase()
         val match = Regex("""(\d+)\s*(second|minute|hour|day|week|month|year)""").find(text)
             ?: return if (text.contains("just now")) System.currentTimeMillis() else 0L
 
@@ -432,21 +365,6 @@ class LightNovelWorld :
         ).remove()
 
         return content.html()
-    }
-
-    // ======================== Preferences ========================
-
-    override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        SwitchPreferenceCompat(screen.context).apply {
-            key = CLEAR_CHAPTER_CACHE_KEY
-            title = "Clear All Cached Chapter Data"
-            summary = "Toggle this to clear cached chapter pagination data for all novels."
-            setDefaultValue(false)
-            setOnPreferenceChangeListener { _, _ ->
-                clearAllChapterCache()
-                true
-            }
-        }.also(screen::addPreference)
     }
 
     // ======================== Filters ========================
@@ -541,7 +459,7 @@ class LightNovelWorld :
     private class TagsExcludeFilter : Filter.Text("Exclude Tags")
 
     companion object {
+        private const val TAG = "LightNovelWorld"
         private const val CHAPTERS_PER_PAGE = 50
-        private const val CLEAR_CHAPTER_CACHE_KEY = "lightnovelworld_clear_chapter_cache"
     }
 }

--- a/src/en/mtlbooks/build.gradle
+++ b/src/en/mtlbooks/build.gradle
@@ -1,8 +1,12 @@
 ext {
     extName = 'MtlBooks'
     extClass = '.MtlBooks'
-    extVersionCode = 3
+    extVersionCode = 4
     isNovel = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:chapterutils"))
+}

--- a/src/en/mtlbooks/src/eu/kanade/tachiyomi/extension/en/mtlbooks/MtlBooks.kt
+++ b/src/en/mtlbooks/src/eu/kanade/tachiyomi/extension/en/mtlbooks/MtlBooks.kt
@@ -1,5 +1,6 @@
 ﻿package eu.kanade.tachiyomi.novelextension.en.mtlbooks
 
+import android.util.Log
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.NovelSource
@@ -7,9 +8,13 @@ import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.lib.chapterutils.incrementalStartPage
+import keiyoushi.lib.chapterutils.mergeChapters
+import keiyoushi.lib.chapterutils.shouldReturnExisting
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -230,23 +235,71 @@ class MtlBooks :
         return POST("$apiUrl/chapters/list", headers, body)
     }
 
-    override fun chapterListParse(response: Response): List<SChapter> {
-        val chapters = mutableListOf<SChapter>()
-        val slug = response.request.url.toString().substringAfter("novel_slug=").substringBefore("&")
+    override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+        val slug = manga.url.substringAfter("/novel/")
 
+        // Page 1 is always required to determine the total chapter count.
+        val page1 = json.decodeFromString<ChapterListResponse>(
+            client.newCall(chapterListRequest(manga)).execute().body.string(),
+        )
+        val pagination = page1.result.pagination
+        val total = pagination.total
+        val limit = pagination.limit
+        val totalPages = (total + limit - 1) / limit
+        val novelSlug = page1.result.novelSlug
+
+        Log.d(TAG, "getChapterList: slug=$slug existing=${context.existingChapters.size} siteTotal=$total totalPages=$totalPages")
+
+        if (shouldReturnExisting(context.existingChapters.size, total)) {
+            Log.d(TAG, "getChapterList: count unchanged — returning existing")
+            return context.existingChapters
+        }
+
+        val existingCount = context.existingChapters.size
+        val startPage = if (existingCount > 0) incrementalStartPage(existingCount, limit) else 1
+        val keepCount = (startPage - 1) * limit
+        Log.d(TAG, "getChapterList: startPage=$startPage keepCount=$keepCount")
+
+        val freshChapters = mutableListOf<SChapter>()
+
+        // Reuse already-fetched page 1 data if it falls within the fresh range.
+        if (startPage == 1) {
+            page1.result.chapterLists.forEach { freshChapters.add(chapterItemToSChapter(novelSlug, it)) }
+        }
+
+        for (page in maxOf(startPage, 2)..totalPages) {
+            try {
+                val body = json.encodeToString(
+                    ChapterListRequest.serializer(),
+                    ChapterListRequest(novelSlug, page, "ASC"),
+                ).toRequestBody("application/json".toMediaType())
+                val pageData = json.decodeFromString<ChapterListResponse>(
+                    client.newCall(POST("$apiUrl/chapters/list", headers, body)).execute().body.string(),
+                )
+                pageData.result.chapterLists.forEach { freshChapters.add(chapterItemToSChapter(novelSlug, it)) }
+            } catch (e: Exception) {
+                Log.w(TAG, "getChapterList: page $page failed — ${e.message}")
+                break
+            }
+        }
+
+        Log.d(TAG, "getChapterList: fresh=${freshChapters.size} keep=$keepCount")
+        return mergeChapters(context.existingChapters, freshChapters, keepCount).reversed()
+    }
+
+    private fun chapterItemToSChapter(novelSlug: String, ch: ChapterItem): SChapter = SChapter.create().apply {
+        url = "/novel/$novelSlug/${ch.chapterSlug}"
+        name = ch.chapterTitle
+        chapter_number = ch.chapterNumber.toFloat()
+    }
+
+    // Fallback path for when getChapterList is not used; performs a full fetch with no optimisation.
+    override fun chapterListParse(response: Response): List<SChapter> {
         val firstPage = json.decodeFromString<ChapterListResponse>(response.body.string())
         val totalPages = (firstPage.result.pagination.total + firstPage.result.pagination.limit - 1) / firstPage.result.pagination.limit
         val novelSlug = firstPage.result.novelSlug
 
-        firstPage.result.chapterLists.forEach { ch ->
-            chapters.add(
-                SChapter.create().apply {
-                    url = "/novel/$novelSlug/${ch.chapterSlug}"
-                    name = ch.chapterTitle
-                    chapter_number = ch.chapterNumber.toFloat()
-                },
-            )
-        }
+        val chapters = firstPage.result.chapterLists.map { chapterItemToSChapter(novelSlug, it) }.toMutableList()
 
         for (page in 2..totalPages) {
             try {
@@ -254,19 +307,10 @@ class MtlBooks :
                     ChapterListRequest.serializer(),
                     ChapterListRequest(novelSlug, page, "ASC"),
                 ).toRequestBody("application/json".toMediaType())
-
-                val pageResponse = client.newCall(POST("$apiUrl/chapters/list", headers, body)).execute()
-                val pageData = json.decodeFromString<ChapterListResponse>(pageResponse.body.string())
-
-                pageData.result.chapterLists.forEach { ch ->
-                    chapters.add(
-                        SChapter.create().apply {
-                            url = "/novel/$novelSlug/${ch.chapterSlug}"
-                            name = ch.chapterTitle
-                            chapter_number = ch.chapterNumber.toFloat()
-                        },
-                    )
-                }
+                val pageData = json.decodeFromString<ChapterListResponse>(
+                    client.newCall(POST("$apiUrl/chapters/list", headers, body)).execute().body.string(),
+                )
+                pageData.result.chapterLists.forEach { chapters.add(chapterItemToSChapter(novelSlug, it)) }
             } catch (_: Exception) {
                 break
             }
@@ -530,4 +574,8 @@ class MtlBooks :
         @SerialName("chapter_slug") val chapterSlug: String,
         val content: String? = null,
     )
+
+    companion object {
+        private const val TAG = "MtlBooks"
+    }
 }

--- a/src/en/novelfire/build.gradle
+++ b/src/en/novelfire/build.gradle
@@ -6,3 +6,7 @@ ext {
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:chapterutils"))
+}

--- a/src/en/novelfire/build.gradle
+++ b/src/en/novelfire/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Novel Fire'
     extClass = '.NovelFire'
-    extVersionCode = 6
+    extVersionCode = 7
     isNovel = true
 }
 

--- a/src/en/novelfire/src/eu/kanade/tachiyomi/extension/en/novelfire/NovelFire.kt
+++ b/src/en/novelfire/src/eu/kanade/tachiyomi/extension/en/novelfire/NovelFire.kt
@@ -17,6 +17,10 @@ import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.lib.chapterutils.checkCloudflare
+import keiyoushi.lib.chapterutils.paginatedChapterList
+import keiyoushi.lib.chapterutils.shouldReturnExisting
+import keiyoushi.lib.chapterutils.sortByChapterNumber
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -395,7 +399,7 @@ class NovelFire :
         val existingCount = context.existingChapters.size
         Log.d(TAG, "getChapterList: manga=${manga.url} existing=$existingCount siteTotal=$totalChapters")
 
-        if (existingCount > 0 && totalChapters > 0 && existingCount == totalChapters) {
+        if (shouldReturnExisting(existingCount, totalChapters)) {
             Log.d(TAG, "getChapterList: count unchanged — returning existing chapters immediately")
             return context.existingChapters
         }
@@ -412,17 +416,32 @@ class NovelFire :
                     throw Exception("Ajax method selected but post_id not found on page")
                 }
             }
-            "html" -> getAllChaptersFromHtmlIncremental(novelPath, context.existingChapters).reversed()
+            "html" -> paginatedChapterList(
+                context = context,
+                siteTotal = totalChapters,
+                assumedPageSize = CHAPTERS_PER_PAGE,
+                fetchPage = { page -> fetchSingleHtmlPage(novelPath, page) },
+            ).reversed()
             else -> {
                 if (postId != null) {
                     try {
-                        getAllChaptersFromHtmlIncremental(novelPath, context.existingChapters).reversed()
+                        paginatedChapterList(
+                            context = context,
+                            siteTotal = totalChapters,
+                            assumedPageSize = CHAPTERS_PER_PAGE,
+                            fetchPage = { page -> fetchSingleHtmlPage(novelPath, page) },
+                        ).reversed()
                     } catch (e: Exception) {
                         Log.d(TAG, "getChapterList: HTML incremental failed (${e.message}), falling back to AJAX")
                         getAllChaptersFromAjax(novelPath, postId).reversed()
                     }
                 } else {
-                    getAllChaptersFromHtmlIncremental(novelPath, context.existingChapters).reversed()
+                    paginatedChapterList(
+                        context = context,
+                        siteTotal = totalChapters,
+                        assumedPageSize = CHAPTERS_PER_PAGE,
+                        fetchPage = { page -> fetchSingleHtmlPage(novelPath, page) },
+                    ).reversed()
                 }
             }
         }
@@ -541,82 +560,6 @@ class NovelFire :
         }.sortedBy { it.chapter_number } // Sort chapters by number ascending
     }
 
-    /**
-     * Fetches only the pages that could contain new chapters, reusing existing data for pages
-     * that are known to be unchanged.
-     *
-     * Uses [CHAPTERS_PER_PAGE] as an initial estimate, then corrects it by reading the actual
-     * chapter count from the first fetched page — but only when that page is a full middle page
-     * (has a next page AND is not page 1). The last page of a novel is always partial, so its
-     * count can't be used to infer page size.
-     *
-     * Because [SyncChaptersWithSource] deduplicates by URL, any harmless overlap between kept
-     * and fresh chapters is silently discarded.
-     *
-     * @param existingChapters chapters already in the DB, sorted newest-first (sourceOrder)
-     */
-    private fun getAllChaptersFromHtmlIncremental(
-        novelPath: String,
-        existingChapters: List<SChapter>,
-    ): List<SChapter> {
-        val existingCount = existingChapters.size
-        if (existingCount == 0) {
-            Log.d(TAG, "incremental: no existing chapters — full fetch from page 1")
-            return getAllChaptersFromHtml(novelPath)
-        }
-
-        // Estimate the start page using the assumed page size constant
-        val estimatedStartPage = ((existingCount - 1) / CHAPTERS_PER_PAGE) + 1
-
-        // Probe that page — if it's a full middle page, its count is the true page size
-        val (probeChapters, probeHasNext) = fetchSingleHtmlPage(novelPath, estimatedStartPage)
-
-        // Detection is only reliable when the page is full (has a next page) and not page 1
-        // (page 1 could be the only page with fewer chapters than the page size)
-        val pageSize = if (probeHasNext && estimatedStartPage > 1 && probeChapters.isNotEmpty()) {
-            probeChapters.size.also { detected ->
-                if (detected != CHAPTERS_PER_PAGE) {
-                    Log.d(TAG, "incremental: detected page size $detected (assumed $CHAPTERS_PER_PAGE)")
-                }
-            }
-        } else {
-            CHAPTERS_PER_PAGE
-        }
-
-        val startPage = ((existingCount - 1) / pageSize) + 1
-        val keepCount = (startPage - 1) * pageSize
-        Log.d(TAG, "incremental: existing=$existingCount pageSize=$pageSize startPage=$startPage keepCount=$keepCount")
-
-        val freshChapters: List<SChapter>
-        if (startPage != estimatedStartPage) {
-            // Page size changed enough to shift which page to start from — discard the probe
-            Log.d(TAG, "incremental: start page shifted $estimatedStartPage→$startPage, re-fetching")
-            freshChapters = getAllChaptersFromHtml(novelPath, startPage)
-        } else {
-            // Reuse the probe page — collect any remaining pages, then sort together
-            val collected = probeChapters.toMutableList()
-            if (probeHasNext) {
-                var page = estimatedStartPage + 1
-                while (true) {
-                    val (pageChapters, hasNext) = fetchSingleHtmlPage(novelPath, page)
-                    collected += pageChapters
-                    if (!hasNext) break
-                    page++
-                }
-            }
-            freshChapters = sortChaptersByNumber(collected)
-        }
-
-        Log.d(TAG, "incremental: fetched ${freshChapters.size} fresh chapters")
-        if (keepCount == 0) return freshChapters
-
-        // existingChapters is newest-first; takeLast(keepCount) gives the oldest keepCount
-        // chapters, then reversed() puts them in ascending order to match freshChapters.
-        val keptOldestFirst = existingChapters.takeLast(keepCount).reversed()
-        Log.d(TAG, "incremental: kept=$keepCount + fresh=${freshChapters.size} = ${keptOldestFirst.size + freshChapters.size} total")
-        return keptOldestFirst + freshChapters
-    }
-
     /** Fetches and parses a single chapter-list page. Returns chapters (unsorted) and whether a next page exists. */
     private fun fetchSingleHtmlPage(novelPath: String, page: Int): Pair<List<SChapter>, Boolean> {
         val pageUrl = "$baseUrl/$novelPath/chapters?page=$page"
@@ -655,15 +598,8 @@ class NovelFire :
             if (!hasNextPage) break
             page++
         }
-        return sortChaptersByNumber(allChapters)
+        return sortByChapterNumber(allChapters)
     }
-
-    private fun sortChaptersByNumber(chapters: List<SChapter>): List<SChapter> = chapters.sortedWith(
-        compareBy { chapter ->
-            Regex("""(?:chapter|ch\.?)\s*(\d+(?:\.\d+)?)""", RegexOption.IGNORE_CASE)
-                .find(chapter.name)?.groupValues?.get(1)?.toDoubleOrNull() ?: Double.MAX_VALUE
-        },
-    )
 
     // ======================== Chapter Content ========================
 
@@ -691,17 +627,6 @@ class NovelFire :
         val content = doc.selectFirst("#content")?.html()
 
         return content ?: ""
-    }
-
-    // ======================== Cloudflare Detection ========================
-
-    private fun checkCloudflare(doc: Document) {
-        val title = doc.title()
-        if (title.contains("Cloudflare", ignoreCase = true) ||
-            doc.selectFirst("title")?.text()?.contains("Cloudflare", ignoreCase = true) == true
-        ) {
-            throw Exception("Cloudflare challenge detected. Please open in WebView.")
-        }
     }
 
     // ======================== Filters ========================

--- a/src/en/wtrlab/build.gradle
+++ b/src/en/wtrlab/build.gradle
@@ -1,8 +1,12 @@
 ext {
     extName = 'WTR-LAB'
     extClass = '.WtrLab'
-    extVersionCode = 4
+    extVersionCode = 5
     isNovel = true
 }
 
 apply from: "$rootDir/common.gradle"
+
+dependencies {
+    implementation(project(":lib:chapterutils"))
+}

--- a/src/en/wtrlab/src/eu/kanade/tachiyomi/extension/en/wtrlab/WtrLab.kt
+++ b/src/en/wtrlab/src/eu/kanade/tachiyomi/extension/en/wtrlab/WtrLab.kt
@@ -13,9 +13,12 @@ import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.RefreshContext
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.lib.chapterutils.mergeChapters
+import keiyoushi.lib.chapterutils.shouldReturnExisting
 import keiyoushi.utils.setAltTitles
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -34,6 +37,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
@@ -717,6 +721,38 @@ class WtrLab :
 
     override fun chapterListRequest(manga: SManga): Request = GET("$baseUrl${manga.url}", headers)
 
+    override suspend fun getChapterList(manga: SManga, context: RefreshContext): List<SChapter> {
+        val response = client.newCall(chapterListRequest(manga)).execute()
+        val html = response.body.string()
+        val doc = Jsoup.parse(html)
+        val url = response.request.url.toString()
+
+        val urlMatch = Regex("""(?:serie-|novel/)(\d+)/([^/]+)""").find(url)
+            ?: return emptyList()
+
+        val rawId = urlMatch.groupValues[1].toInt()
+        val slug = urlMatch.groupValues[2]
+        val chapterCount = extractChapterCount(doc)
+
+        if (chapterCount == 0) return emptyList()
+
+        Log.d(TAG, "getChapterList: rawId=$rawId existing=${context.existingChapters.size} siteTotal=$chapterCount")
+
+        if (shouldReturnExisting(context.existingChapters.size, chapterCount)) {
+            Log.d(TAG, "getChapterList: count unchanged — returning existing")
+            return context.existingChapters
+        }
+
+        val existingCount = context.existingChapters.size
+        val startOrder = if (existingCount > 0) existingCount + 1 else 1
+        val keepCount = startOrder - 1
+
+        Log.d(TAG, "getChapterList: startOrder=$startOrder keepCount=$keepCount")
+
+        val fresh = fetchAllChapters(rawId, chapterCount, slug, startOrder)
+        return mergeChapters(context.existingChapters, fresh, keepCount).reversed()
+    }
+
     override fun chapterListParse(response: Response): List<SChapter> {
         val html = response.body.string()
         val doc = Jsoup.parse(html)
@@ -727,42 +763,39 @@ class WtrLab :
 
         val rawId = urlMatch.groupValues[1].toInt()
         val slug = urlMatch.groupValues[2]
+        val chapterCount = extractChapterCount(doc)
 
-        var chapterCount = 0
-
-        val pageText = doc.text()
-        val chapterCountMatch = Regex("""(\d+)\s+Chapters?""", RegexOption.IGNORE_CASE).find(pageText)
-        if (chapterCountMatch != null) {
-            chapterCount = chapterCountMatch.groupValues[1].toIntOrNull() ?: 0
-        }
-
-        if (chapterCount == 0) {
-            val nextDataText = doc.selectFirst("#__NEXT_DATA__")?.data()
-            if (nextDataText != null) {
-                try {
-                    val jsonData = json.parseToJsonElement(nextDataText).jsonObject
-                    val serieData = jsonData["props"]?.jsonObject
-                        ?.get("pageProps")?.jsonObject
-                        ?.get("serie")?.jsonObject
-                        ?.get("serie_data")?.jsonObject
-                    chapterCount = serieData?.get("chapter_count")?.jsonPrimitive?.intOrNull ?: 0
-                } catch (e: Exception) {
-                }
-            }
-        }
-
-        if (chapterCount == 0) {
-            return emptyList()
-        }
+        if (chapterCount == 0) return emptyList()
 
         return fetchAllChapters(rawId, chapterCount, slug).reversed()
     }
 
-    private fun fetchAllChapters(rawId: Int, totalChapters: Int, slug: String): List<SChapter> {
+    private fun extractChapterCount(doc: Document): Int {
+        // Prefer the structured JSON data — it's precise and unambiguous
+        val nextDataText = doc.selectFirst("#__NEXT_DATA__")?.data()
+        if (nextDataText != null) {
+            try {
+                val jsonData = json.parseToJsonElement(nextDataText).jsonObject
+                val count = jsonData["props"]?.jsonObject
+                    ?.get("pageProps")?.jsonObject
+                    ?.get("serie")?.jsonObject
+                    ?.get("serie_data")?.jsonObject
+                    ?.get("chapter_count")?.jsonPrimitive?.intOrNull ?: 0
+                if (count > 0) return count
+            } catch (e: Exception) {
+            }
+        }
+
+        // Fallback: scan page text for "N Chapters" (less reliable but covers older layouts)
+        return Regex("""(\d+)\s+Chapters?""", RegexOption.IGNORE_CASE)
+            .find(doc.text())?.groupValues?.get(1)?.toIntOrNull() ?: 0
+    }
+
+    private fun fetchAllChapters(rawId: Int, totalChapters: Int, slug: String, startOrder: Int = 1): List<SChapter> {
         val allChapters = mutableListOf<SChapter>()
         val batchSize = 250
 
-        var start = 1
+        var start = startOrder
         while (start <= totalChapters) {
             val end = minOf(start + batchSize - 1, totalChapters)
 
@@ -793,6 +826,7 @@ class WtrLab :
                 if (chapters.size < batchSize) break
                 start += batchSize
             } catch (e: Exception) {
+                Log.w(TAG, "fetchAllChapters: batch start=$start failed — ${e.message}")
                 break
             }
         }
@@ -869,6 +903,10 @@ class WtrLab :
         FoldersFilter(),
         LibraryExcludeFilter(),
     )
+
+    companion object {
+        private const val TAG = "WtrLab"
+    }
 }
 
 private const val TRANSLATION_MODE_KEY = "translationMode"


### PR DESCRIPTION
Moved RefreshContext code into a common lib, implemented a few references for it.
May have errors, but brief testing of each one seemed to go fine.
When it fails to detect the amount of chapters, it just fetches all, so no loss of functionality so far.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Have not changed source names
- [x] Have tested the modifications by compiling and running the extension through Android Studio
