### PR TITLE
fix(en:BrightNovels): ascending chapter order + strip chapter-number prefix

### DIFF
--- a/src/en/brightnovels/build.gradle
+++ b/src/en/brightnovels/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Bright Novels'
     extClass = '.BrightNovels'
-    extVersionCode = 3
+    extVersionCode = 4
     isNovel = true
 }
 

--- a/src/en/brightnovels/src/eu/kanade/tachiyomi/extension/en/brightnovels/BrightNovels.kt
+++ b/src/en/brightnovels/src/eu/kanade/tachiyomi/extension/en/brightnovels/BrightNovels.kt
@@ -241,7 +241,7 @@ class BrightNovels :
         if (seriesSlug.isBlank()) {
             return extractChapterObjects(page, series)
                 .mapNotNull { chapterElement -> chapterToSChapter(chapterElement, seriesSlug, showPremium) }
-                .sortedByDescending { it.chapter_number }
+                .sortedBy { it.chapter_number }
         }
 
         val chapterElements = linkedMapOf<String, JsonElement>()
@@ -265,7 +265,7 @@ class BrightNovels :
 
         return chapterElements.values
             .mapNotNull { chapterToSChapter(it, seriesSlug, showPremium) }
-            .sortedByDescending { it.chapter_number }
+            .sortedBy { it.chapter_number }
     }
 
     override fun pageListRequest(chapter: SChapter): Request = inertiaRequest(absoluteUrl(chapter.url))
@@ -694,9 +694,14 @@ class BrightNovels :
         val chapterNumber = chapter["number"].asPrimitive()?.contentOrNull?.toFloatOrNull()
             ?: chapterSlug.toFloatOrNull()
             ?: -1f
-        val chapterName = chapter.string("name")
+        val rawName = chapter.string("name")
             ?: chapter.string("title")
             ?: "Chapter ${chapter.string("number") ?: ""}".trim()
+
+        val chapterName = rawName
+            .replace(Regex("""^\s*(?:chapter|chap|ch\.?|episode|ep\.?)?\s*\d+(?:\.\d+)?\s*[:\-–.)]*\s*""", RegexOption.IGNORE_CASE), "")
+            .trim()
+            .ifBlank { rawName }
 
         return SChapter.create().apply {
             name = chapterName


### PR DESCRIPTION

Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
