### PR TITLE
feat(novel): preserve description line breaks with shared formattedText

### DIFF
--- a/core/src/main/kotlin/keiyoushi/utils/Jsoup.kt
+++ b/core/src/main/kotlin/keiyoushi/utils/Jsoup.kt
@@ -1,0 +1,28 @@
+package keiyoushi.utils
+
+import org.jsoup.nodes.Element
+
+/**
+ * Returns the element's text with block boundaries and `<br>` preserved as
+ * newlines, unlike [Element.text] which collapses them to single spaces.
+ *
+ * Use for descriptions/synopses where paragraph breaks matter.
+ */
+fun Element.formattedText(): String {
+    val breakToken = "__KEIYO_BR__"
+    val paragraphToken = "__KEIYO_P__"
+    val node = clone()
+    node.select("script, style").remove()
+    node.select("br").forEach { it.after(breakToken) }
+    node.select("p, div, h1, h2, h3, h4, h5, h6, li")
+        // the root element itself can match but has no parent on the clone,
+        // so after() would throw
+        .filter { it !== node }
+        .forEach { it.after(paragraphToken) }
+    return node.text()
+        .replace(Regex("\\u00A0"), " ")
+        .replace(Regex("""\s*$paragraphToken\s*"""), "\n\n")
+        .replace(Regex("""\s*$breakToken\s*"""), "\n")
+        .replace(Regex("\n{3,}"), "\n\n")
+        .trim()
+}

--- a/lib-multisrc/lightnovelworld/src/eu/kanade/tachiyomi/multisrc/lightnovelworld/LightNovelWorld.kt
+++ b/lib-multisrc/lightnovelworld/src/eu/kanade/tachiyomi/multisrc/lightnovelworld/LightNovelWorld.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.formattedText
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response
@@ -106,7 +107,7 @@ open class LightNovelWorld(
             title = doc.selectFirst("h1.novel-title")?.text()?.trim() ?: "Untitled"
             thumbnail_url = doc.selectFirst("figure.cover > img")?.attr("data-src")
             author = doc.selectFirst(".author > a > span")?.text()
-            description = doc.selectFirst(".summary > .content")?.text()?.trim()
+            description = doc.selectFirst(".summary > .content")?.formattedText()
             genre = doc.select(".categories ul li").joinToString { it.text().trim() }
             status = when (doc.selectFirst(".header-stats span:last-child strong")?.text()?.trim()?.lowercase()) {
                 "ongoing" -> SManga.ONGOING

--- a/lib-multisrc/lightnovelwp/src/eu/kanade/tachiyomi/multisrc/lightnovelwp/LightNovelWP.kt
+++ b/lib-multisrc/lightnovelwp/src/eu/kanade/tachiyomi/multisrc/lightnovelwp/LightNovelWP.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.formattedText
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -142,7 +143,7 @@ abstract class LightNovelWP(
         }
 
         // Get summary
-        description = document.selectFirst(".entry-content, div[itemprop=description]")?.text()?.trim()
+        description = document.selectFirst(".entry-content, div[itemprop=description]")?.formattedText()
 
         // Parse info section for author/status
         document.select(".spe span, .serl span, .sertostat").forEach { element ->

--- a/lib-multisrc/lightnovelwpnovel/src/eu/kanade/tachiyomi/multisrc/lightnovelwpnovel/LightNovelWPNovel.kt
+++ b/lib-multisrc/lightnovelwpnovel/src/eu/kanade/tachiyomi/multisrc/lightnovelwpnovel/LightNovelWPNovel.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import keiyoushi.utils.setAltTitles
 import okhttp3.Request
 import okhttp3.Response
@@ -149,7 +150,7 @@ open class LightNovelWPNovel(
                 ?: doc.selectFirst(".post-title h1")?.text()?.trim()?.takeIf { it.isNotBlank() }
                 ?: "Unknown Title"
 
-            description = doc.selectFirst(".entry-content, [itemprop=description]")?.text()?.trim() ?: ""
+            description = doc.selectFirst(".entry-content, [itemprop=description]")?.formattedText() ?: ""
 
             val authorElement = doc.select(".spe span:contains(Author), .serl:contains(Author)").first()
             author = authorElement?.nextElementSibling()?.text()?.trim()

--- a/src/ar/freekolnovel/build.gradle
+++ b/src/ar/freekolnovel/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.FreeKolNovel'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://free.kolnovel.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/ar/galaxynovels/build.gradle
+++ b/src/ar/galaxynovels/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Galaxy Novels'
     extClass = '.GalaxyNovels'
-    extVersionCode = 2
+    extVersionCode = 3
     isNsfw = false
     isNovel = true
 }

--- a/src/ar/galaxynovels/src/eu/kanade/tachiyomi/extension/ar/galaxynovels/GalaxyNovels.kt
+++ b/src/ar/galaxynovels/src/eu/kanade/tachiyomi/extension/ar/galaxynovels/GalaxyNovels.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -200,10 +201,7 @@ class GalaxyNovels :
                 else -> SManga.UNKNOWN
             }
 
-            description = doc.selectFirst(".wor-single-summary__text")?.let { element ->
-                element.select("script, style").remove()
-                element.text().trim()
-            }
+            description = doc.selectFirst(".wor-single-summary__text")?.formattedText()
 
             val chapterCountText = doc.select(".wor-single-stats__item")
                 .firstOrNull { it.text().contains("عدد الفصول") }

--- a/src/ar/kolnovel/build.gradle
+++ b/src/ar/kolnovel/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KolNovel'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://kolnovel.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/ar/novelsparadise/build.gradle
+++ b/src/ar/novelsparadise/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NovelsParadise'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://novelsparadise.site'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/asiannovel/build.gradle
+++ b/src/en/asiannovel/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'AsianNovel'
     extClass = '.AsianNovel'
-    extVersionCode = 3
+    extVersionCode = 4
     isNovel = true
 }
 

--- a/src/en/asiannovel/src/eu/kanade/tachiyomi/extension/en/asiannovel/AsianNovel.kt
+++ b/src/en/asiannovel/src/eu/kanade/tachiyomi/extension/en/asiannovel/AsianNovel.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -204,7 +205,7 @@ class AsianNovel :
 
             author = document.selectFirst(".story__identity-meta .author")?.text()
 
-            description = document.selectFirst(".story__summary p")?.text()
+            description = document.selectFirst(".story__summary")?.formattedText()
 
             genre = document.select(".story__taxonomies .tag-pill").map { it.text() }.joinToString(", ")
 

--- a/src/en/daotranslate/build.gradle
+++ b/src/en/daotranslate/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.DaoTranslate'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://daotranslate.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/honeyfeed/build.gradle
+++ b/src/en/honeyfeed/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Honeyfeed'
     extClass = '.Honeyfeed'
-    extVersionCode = 2
+    extVersionCode = 3
     isNovel = true
 }
 

--- a/src/en/honeyfeed/src/eu/kanade/tachiyomi/extension/en/honeyfeed/Honeyfeed.kt
+++ b/src/en/honeyfeed/src/eu/kanade/tachiyomi/extension/en/honeyfeed/Honeyfeed.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -97,7 +98,7 @@ class Honeyfeed :
 
         return SManga.create().apply {
             title = doc.selectFirst("div.mt8")?.text() ?: ""
-            description = doc.selectFirst(".wrap-novel-body")?.text()
+            description = doc.selectFirst(".wrap-novel-body")?.formattedText()
             thumbnail_url = doc.selectFirst(".wrap-img-novel-mask img")?.attr("src") ?: logoUrl
             status = when (doc.selectFirst("span.pr8")?.text()) {
                 "Ongoing" -> SManga.ONGOING

--- a/src/en/ippotranslation/build.gradle
+++ b/src/en/ippotranslation/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.IppoTranslation'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://ippotranslations.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/kdtnovels/build.gradle
+++ b/src/en/kdtnovels/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KdtNovels'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://kdtnovels.net'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/knoxt/build.gradle
+++ b/src/en/knoxt/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KnoxT'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://knoxt.space'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/lazygirltranslations/build.gradle
+++ b/src/en/lazygirltranslations/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LazyGirlTranslations'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://lazygirltranslations.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/libread/build.gradle
+++ b/src/en/libread/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LibRead'
     themePkg = 'readnovelfull'
     baseUrl = 'https://libread.com'
-    overrideVersionCode = 2
+    overrideVersionCode = 3
     isNsfw = false
     isNovel = true
 }

--- a/src/en/libread/src/eu/kanade/tachiyomi/extension/en/libread/LibRead.kt
+++ b/src/en/libread/src/eu/kanade/tachiyomi/extension/en/libread/LibRead.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.util.asJsoup
+import keiyoushi.utils.formattedText
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
@@ -207,7 +208,7 @@ class LibRead :
             }
         }
         if (manga.description.isNullOrBlank()) {
-            manga.description = document.selectFirst("div.m-desc div.txt div.inner, div.desc-text")?.text()?.trim()
+            manga.description = document.selectFirst("div.m-desc div.txt div.inner, div.desc-text")?.formattedText()
         }
 
         return manga

--- a/src/en/lncrawler/build.gradle
+++ b/src/en/lncrawler/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'LnCrawler'
     extClass = '.LnCrawler'
-    extVersionCode = 3
+    extVersionCode = 4
     isNovel = true
 }
 

--- a/src/en/lncrawler/src/eu/kanade/tachiyomi/extension/en/lncrawler/LnCrawler.kt
+++ b/src/en/lncrawler/src/eu/kanade/tachiyomi/extension/en/lncrawler/LnCrawler.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -432,7 +433,7 @@ class LnCrawler :
         title = novel.title
         thumbnail_url = resolveCover(novel.preferedSource?.coverMinUrl ?: novel.preferedSource?.coverUrl)
         author = novel.preferedSource?.authors?.firstOrNull()
-        description = novel.preferedSource?.synopsis?.let { Jsoup.parse(it).text() }
+        description = novel.preferedSource?.synopsis?.let { Jsoup.parse(it).formattedText() }
         genre = novel.preferedSource?.tags?.take(5)?.joinToString(", ") ?: ""
     }
 

--- a/src/en/lnori/build.gradle
+++ b/src/en/lnori/build.gradle
@@ -1,7 +1,7 @@
     ext {
     extName = 'Lnori'
     extClass = '.Lnori'
-    extVersionCode = 4
+    extVersionCode = 5
     isNovel = true
 }
 

--- a/src/en/lnori/src/eu/kanade/tachiyomi/extension/en/lnori/Lnori.kt
+++ b/src/en/lnori/src/eu/kanade/tachiyomi/extension/en/lnori/Lnori.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -499,9 +500,9 @@ class Lnori :
             description = document.selectFirst(
                 "p.description, .series-description, .synopsis, [itemprop='description'], " +
                     ".desc, .summary, [class*=description], [class*=synopsis]",
-            )?.text()?.trim() ?: run {
+            )?.formattedText() ?: run {
                 // Fallback: find paragraph with >80 chars that's likely the description
-                document.select("p").firstOrNull { it.text().length > 80 }?.text()?.trim()
+                document.select("p").firstOrNull { it.text().length > 80 }?.formattedText()
             }
 
             // Genres/Tags

--- a/src/en/mtlreader/build.gradle
+++ b/src/en/mtlreader/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MTL Reader'
     extClass = '.MtlReader'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/mtlreader/src/eu/kanade/tachiyomi/extension/en/mtlreader/MtlReader.kt
+++ b/src/en/mtlreader/src/eu/kanade/tachiyomi/extension/en/mtlreader/MtlReader.kt
@@ -12,6 +12,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import keiyoushi.utils.getPreferencesLazy
 import okhttp3.Request
 import okhttp3.Response
@@ -123,7 +124,7 @@ class MtlReader :
                 ?: doc.selectFirst("img.thumbnail")?.attr("src")
                 ?: doc.selectFirst(".property_img img")?.attr("src")
 
-            description = doc.selectFirst("#editdescription")?.text()?.trim()
+            description = doc.selectFirst("#editdescription")?.formattedText()
                 ?: doc.selectFirst("meta[name=description]")?.attr("content")
                 ?: doc.selectFirst(".novel-description")?.text()
                 ?: ""

--- a/src/en/mvlempyr/build.gradle
+++ b/src/en/mvlempyr/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'MVLEMPYR'
     extClass = '.MVLEMPYR'
-    extVersionCode = 1
+    extVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/mvlempyr/src/eu/kanade/tachiyomi/extension/en/mvlempyr/MVLEMPYR.kt
+++ b/src/en/mvlempyr/src/eu/kanade/tachiyomi/extension/en/mvlempyr/MVLEMPYR.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -492,7 +493,7 @@ class MVLEMPYR :
         }
     }
 
-    private fun cleanHtml(html: String): String = Jsoup.parse(html).text()
+    private fun cleanHtml(html: String): String = Jsoup.parse(html).formattedText()
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
     }

--- a/src/en/novelable/build.gradle
+++ b/src/en/novelable/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Novelable'
     extClass = '.Novelable'
-    extVersionCode = 2
+    extVersionCode = 3
     isNovel = true
 }
 

--- a/src/en/novelable/src/eu/kanade/tachiyomi/extension/en/novelable/Novelable.kt
+++ b/src/en/novelable/src/eu/kanade/tachiyomi/extension/en/novelable/Novelable.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -106,7 +107,7 @@ class Novelable :
             }
 
             // Description from summary section
-            description = document.selectFirst("div.summary p.content")?.text()
+            description = document.selectFirst("div.summary p.content")?.formattedText()
                 ?: document.selectFirst(".novel-synopsis, .novel-description, .description")?.text()
 
             // Genre/Tags from meta box

--- a/src/en/novelfire/build.gradle
+++ b/src/en/novelfire/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Novel Fire'
     extClass = '.NovelFire'
-    extVersionCode = 7
+    extVersionCode = 8
     isNovel = true
 }
 

--- a/src/en/novelfire/src/eu/kanade/tachiyomi/extension/en/novelfire/NovelFire.kt
+++ b/src/en/novelfire/src/eu/kanade/tachiyomi/extension/en/novelfire/NovelFire.kt
@@ -21,6 +21,7 @@ import keiyoushi.lib.chapterutils.checkCloudflare
 import keiyoushi.lib.chapterutils.paginatedChapterList
 import keiyoushi.lib.chapterutils.shouldReturnExisting
 import keiyoushi.lib.chapterutils.sortByChapterNumber
+import keiyoushi.utils.formattedText
 import keiyoushi.utils.tryParse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -346,7 +347,7 @@ class NovelFire :
                 .joinToString(", ") { it.text().trim() }
 
             // Get summary
-            val summary = doc.selectFirst(".summary .content")?.text()?.trim()
+            val summary = doc.selectFirst(".summary .content")?.formattedText()
             description = summary?.replace("Show More", "") ?: "No Summary Found"
 
             // Get author

--- a/src/en/novelsknight/build.gradle
+++ b/src/en/novelsknight/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NovelsKnight'
     themePkg = 'lightnovelwp'
     baseUrl = 'https://novelsknight.punchmanga.online'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/novelsknight/src/eu/kanade/tachiyomi/extension/en/novelsknight/NovelsKnight.kt
+++ b/src/en/novelsknight/src/eu/kanade/tachiyomi/extension/en/novelsknight/NovelsKnight.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
 import okhttp3.Response
@@ -133,7 +134,7 @@ class NovelsKnight :
             thumbnail_url = doc.selectFirst("div.sertothumb img")?.attr("src")
 
             // Description from div.sersysn div.sersys
-            description = doc.selectFirst("div.sersysn div.sersys")?.text()?.trim()
+            description = doc.selectFirst("div.sersysn div.sersys")?.formattedText()
 
             // Author from span.sername:contains(Author) + span.serval
             author = doc.selectFirst("div.serl:has(span.sername:contains(Author)) span.serval")?.text()?.trim()

--- a/src/en/pawread/build.gradle
+++ b/src/en/pawread/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'PawRead'
     extClass = '.PawRead'
-    extVersionCode = 1
+    extVersionCode = 2
     isNovel = true
 }
 

--- a/src/en/pawread/src/eu/kanade/tachiyomi/extension/en/pawread/PawRead.kt
+++ b/src/en/pawread/src/eu/kanade/tachiyomi/extension/en/pawread/PawRead.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -149,7 +150,7 @@ class PawRead :
             genre = doc.select("a.btn-default").joinToString(", ") { it.text().trim() }
 
             // Summary from #full-des
-            description = doc.selectFirst("#full-des")?.text()?.trim()
+            description = doc.selectFirst("#full-des")?.formattedText()
         }
     }
 

--- a/src/en/penguinsquad/build.gradle
+++ b/src/en/penguinsquad/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'PenguinSquad'
     extClass = '.PenguinSquad'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
     isNovel = true
 }

--- a/src/en/penguinsquad/src/eu/kanade/tachiyomi/extension/en/penguinsquad/PenguinSquad.kt
+++ b/src/en/penguinsquad/src/eu/kanade/tachiyomi/extension/en/penguinsquad/PenguinSquad.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
 import keiyoushi.utils.extractNextJs
+import keiyoushi.utils.formattedText
 import keiyoushi.utils.getPreferencesLazy
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -100,7 +101,7 @@ class PenguinSquad :
             url = "/novels/${response.request.url.pathSegments.last()}"
             title = doc.selectFirst("h1")?.text().orEmpty()
             thumbnail_url = doc.selectFirst("img[src*=/covers/]")?.absUrl("src")
-            description = doc.selectFirst("p[class*=line-clamp-3]")?.text()
+            description = doc.selectFirst("p[class*=line-clamp-3]")?.formattedText()
             genre = doc.select("span[data-slot=badge][data-variant=outline]")
                 .eachText()
                 .distinct()

--- a/src/en/ranobes/build.gradle
+++ b/src/en/ranobes/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Ranobes'
     extClass = '.Ranobes'
-    extVersionCode = 2
+    extVersionCode = 3
     isNovel = true
 }
 

--- a/src/en/ranobes/src/eu/kanade/tachiyomi/extension/en/ranobes/Ranobes.kt
+++ b/src/en/ranobes/src/eu/kanade/tachiyomi/extension/en/ranobes/Ranobes.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import keiyoushi.utils.getPreferencesLazy
 import okhttp3.FormBody
 import okhttp3.Request
@@ -69,7 +70,7 @@ class Ranobes :
                     if (it.startsWith("http")) it else baseUrl + it
                 }
 
-                description = article.selectFirst("div.moreless__short")?.text()?.trim()
+                description = article.selectFirst("div.moreless__short")?.formattedText()
 
                 genre = article.select("div.rank-story-genre a").joinToString(", ") {
                     it.text().trim()
@@ -186,7 +187,7 @@ class Ranobes :
                     extractBackgroundUrl(it)
                 }
 
-                description = article.selectFirst("div.cont-in > div")?.text()?.trim()
+                description = article.selectFirst("div.cont-in > div")?.formattedText()
 
                 genre = article.selectFirst("div.r-rate div.grey")?.text()?.trim()
 
@@ -223,7 +224,7 @@ class Ranobes :
                     it.attr("src").ifEmpty { extractBackgroundUrl(it.attr("style") ?: "") }
                 }?.let { if (it.startsWith("http")) it else baseUrl + it }
 
-                description = article.selectFirst("div.moreless__short")?.text()?.trim()
+                description = article.selectFirst("div.moreless__short")?.formattedText()
 
                 genre = article.select("div.rank-story-genre a, .genre a").joinToString(", ") {
                     it.text().trim()

--- a/src/en/readnovelmtl/build.gradle
+++ b/src/en/readnovelmtl/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'ReadNovelMtl'
     extClass = '.ReadNovelMtl'
-    extVersionCode = 2
+    extVersionCode = 3
     isNovel = true
 }
 

--- a/src/en/readnovelmtl/src/eu/kanade/tachiyomi/extension/en/readnovelmtl/ReadNovelMtl.kt
+++ b/src/en/readnovelmtl/src/eu/kanade/tachiyomi/extension/en/readnovelmtl/ReadNovelMtl.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -154,7 +155,7 @@ class ReadNovelMtl :
 
             author = document.selectFirst("a[href*=author=]")?.text()
 
-            description = document.selectFirst(".mb-4[style*=font-size]")?.text()
+            description = document.selectFirst(".mb-4[style*=font-size]")?.formattedText()
 
             genre = document.select(".d-flex.flex-wrap.gap-2 a.badge").map { it.text() }.joinToString(", ")
 

--- a/src/en/requiemtranslations/build.gradle
+++ b/src/en/requiemtranslations/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Requiem Translations'
     extClass = '.RequiemTranslations'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     themePkg = 'lightnovelwpnovel'
     isNovel = true
 }

--- a/src/en/royalroad/build.gradle
+++ b/src/en/royalroad/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Royal Road'
     extClass = '.RoyalRoad'
-    extVersionCode = 3
+    extVersionCode = 4
     isNovel = true
 }
 

--- a/src/en/royalroad/src/eu/kanade/tachiyomi/extension/en/royalroad/RoyalRoad.kt
+++ b/src/en/royalroad/src/eu/kanade/tachiyomi/extension/en/royalroad/RoyalRoad.kt
@@ -13,6 +13,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -384,7 +385,7 @@ class RoyalRoad :
             ?: doc.select("a[href^=/profile/]").first()?.text() ?: ""
 
         // Description - get the hidden full description if available
-        val description = doc.selectFirst("div.description div.hidden-content")?.text()
+        val description = doc.selectFirst("div.description div.hidden-content")?.formattedText()
             ?: doc.selectFirst("div.description")?.text()
             ?: ""
 

--- a/src/en/scribblehub/build.gradle
+++ b/src/en/scribblehub/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Scribble Hub'
     extClass = '.ScribbleHub'
-    extVersionCode = 3
+    extVersionCode = 4
     isNsfw = false
     isNovel = true
 }

--- a/src/en/scribblehub/src/eu/kanade/tachiyomi/extension/en/scribblehub/ScribbleHub.kt
+++ b/src/en/scribblehub/src/eu/kanade/tachiyomi/extension/en/scribblehub/ScribbleHub.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.Response
@@ -142,7 +143,7 @@ class ScribbleHub :
                 else -> SManga.UNKNOWN
             }
 
-            description = doc.select(".wi_fic_desc").text().trim()
+            description = doc.selectFirst(".wi_fic_desc")?.formattedText().orEmpty()
         }
     }
 

--- a/src/en/systemtranslation/build.gradle
+++ b/src/en/systemtranslation/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SystemTranslation'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://systemtranslation.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/transweaver/build.gradle
+++ b/src/en/transweaver/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.TranslationWeaver'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://transweaver.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/universalnovel/build.gradle
+++ b/src/en/universalnovel/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.UniversalNovel'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://universalnovel.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/en/vynovel/build.gradle
+++ b/src/en/vynovel/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Vynovel'
     extClass = '.Vynovel'
-    extVersionCode = 2
+    extVersionCode = 3
     isNovel = true
 }
 

--- a/src/en/vynovel/src/eu/kanade/tachiyomi/extension/en/vynovel/Vynovel.kt
+++ b/src/en/vynovel/src/eu/kanade/tachiyomi/extension/en/vynovel/Vynovel.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
+import keiyoushi.utils.formattedText
 import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.Jsoup
@@ -158,7 +159,7 @@ class Vynovel :
                 .joinToString(", ")
 
             // Description
-            description = document.selectFirst("div.summary p.content")?.text()?.trim()
+            description = document.selectFirst("div.summary p.content")?.formattedText()
         }
     }
 

--- a/src/es/tcsega/build.gradle
+++ b/src/es/tcsega/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.TCandSega'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://teamchmantranslations.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/fr/lightnovelfr/build.gradle
+++ b/src/fr/lightnovelfr/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.LightNovelFR'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://lightnovelfr.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/id/bacalightnovel/build.gradle
+++ b/src/id/bacalightnovel/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.BacaLightNovel'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://bacalightnovel.co'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/id/sektenovel/build.gradle
+++ b/src/id/sektenovel/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.SekteNovel'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://sektenovel.web.id'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/pt/centralnovel/build.gradle
+++ b/src/pt/centralnovel/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.CentralNovel'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://centralnovel.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/tr/kodekslibrary/build.gradle
+++ b/src/tr/kodekslibrary/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.KodeksLibrary'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://www.kodekslibrary.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/tr/namevt/build.gradle
+++ b/src/tr/namevt/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.Namevt'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://namevt.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }

--- a/src/tr/noveltr/build.gradle
+++ b/src/tr/noveltr/build.gradle
@@ -3,7 +3,7 @@ ext {
     extClass = '.NovelTR'
     themePkg = 'lightnovelwpnovel'
     baseUrl = 'https://noveltr.com'
-    overrideVersionCode = 1
+    overrideVersionCode = 2
     isNsfw = false
     isNovel = true
 }


### PR DESCRIPTION
…t util

Many novel sources built descriptions with Jsoup's text(), which collapses <br>/<p> and newlines into single spaces. Add Element.formattedText() to keiyoushi.utils

Sources: lightnovelworld, lightnovelwp, lightnovelwpnovel, galaxynovels, asiannovel, honeyfeed, libread, lightnoveltranslation, lncrawler, lnori, mtlreader, mvlempyr, novelable, novelbuddy, novelfire, novelsknight, pawread, penguinsquad, ranobes, readnovelmtl, royalroad, scribblehub, vynovel.

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
