### PR TITLE
fix(en): surface chapter list errors in Konkon and KuuPress

### DIFF
--- a/src/en/konkon/src/eu/kanade/tachiyomi/extension/en/konkon/Konkon.kt
+++ b/src/en/konkon/src/eu/kanade/tachiyomi/extension/en/konkon/Konkon.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.stripChapterNumberPrefix
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -249,16 +250,12 @@ class Konkon :
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val body = response.body.string()
-        return try {
-            val root = json.parseToJsonElement(body).jsonObject
-            val data = root["data"]?.jsonObject ?: JsonObject(emptyMap())
-            cacheBookmarkState(data.str("slug").orEmpty(), root)
-            parseChaptersFromNovelData(data)
-                .sortedByDescending { it.sortKey }
-                .map { it.chapter }
-        } catch (_: Exception) {
-            emptyList()
-        }
+        val root = json.parseToJsonElement(body).jsonObject
+        val data = root["data"]?.jsonObject ?: JsonObject(emptyMap())
+        cacheBookmarkState(data.str("slug").orEmpty(), root)
+        return parseChaptersFromNovelData(data)
+            .sortedByDescending { it.sortKey }
+            .map { it.chapter }
     }
 
     override fun fetchChapterList(manga: SManga): rx.Observable<List<SChapter>> = rx.Observable.fromCallable {
@@ -339,9 +336,17 @@ class Konkon :
     override fun pageListParse(response: Response): List<Page> = listOf(Page(0, response.request.url.toString()))
 
     override suspend fun fetchPageText(page: Page): String {
-        val chapterUrl = if (page.url.startsWith("http")) page.url else baseUrl + page.url
-
-        val response = client.newCall(GET(chapterUrl, headers)).execute()
+        // page.url may be the API stub (.../chapters/<id>) or the site chapter path
+        // (/read/chapter/<id>/<slug>); always resolve to the JSON content endpoint.
+        val contentUrl = if (page.url.contains("/api/public/chapters/")) {
+            page.url
+        } else {
+            val chapterId = page.url.substringBefore('?').trim('/').split('/')
+                .firstOrNull { seg -> seg.isNotEmpty() && seg.all(Char::isDigit) }
+                ?: page.url.substringAfterLast('/')
+            "$apiBase/chapters/$chapterId"
+        }
+        val response = client.newCall(GET(contentUrl, headers)).execute()
         val body = response.body.string()
         val resolvedUrl = response.request.url
 
@@ -378,7 +383,6 @@ class Konkon :
         SearchQueryFilter(),
     )
 
-    // ======================== Tracking ========================
 
     override val supportsChapterTracking = false
 
@@ -463,7 +467,6 @@ class Konkon :
         return java.net.URLDecoder.decode(raw, "UTF-8")
     }
 
-    // ======================== Settings ========================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {
@@ -571,7 +574,7 @@ class Konkon :
                             .trim('-')
                     }
                     url = "/read/chapter/$chapterId/$chapterSlug"
-                    name = visibleTitle.ifBlank { "Chapter $sortOrder" }
+                    name = visibleTitle.stripChapterNumberPrefix().ifBlank { "Chapter $sortOrder" }
                     chapter_number = chapterNumber
                     date_upload = parseDate(chapter.str("scheduled_for") ?: chapter.str("created_at"))
                 }

--- a/src/en/konkon/src/eu/kanade/tachiyomi/extension/en/konkon/Konkon.kt
+++ b/src/en/konkon/src/eu/kanade/tachiyomi/extension/en/konkon/Konkon.kt
@@ -383,7 +383,6 @@ class Konkon :
         SearchQueryFilter(),
     )
 
-
     override val supportsChapterTracking = false
 
     override val supportsFavoritesTracking: Boolean
@@ -466,7 +465,6 @@ class Konkon :
         } ?: return null
         return java.net.URLDecoder.decode(raw, "UTF-8")
     }
-
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {

--- a/src/en/kuupress/build.gradle
+++ b/src/en/kuupress/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'KuuPress'
     extClass = '.KuuPress'
-    extVersionCode = 5
+    extVersionCode = 6
     isNsfw = false
     isNovel = true
 }

--- a/src/en/kuupress/src/eu/kanade/tachiyomi/extension/en/kuupress/KuuPress.kt
+++ b/src/en/kuupress/src/eu/kanade/tachiyomi/extension/en/kuupress/KuuPress.kt
@@ -382,7 +382,6 @@ class KuuPress :
         SearchQueryFilter(),
     )
 
-
     override val supportsChapterTracking = false
 
     override val supportsFavoritesTracking: Boolean
@@ -465,7 +464,6 @@ class KuuPress :
         } ?: return null
         return java.net.URLDecoder.decode(raw, "UTF-8")
     }
-
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {

--- a/src/en/kuupress/src/eu/kanade/tachiyomi/extension/en/kuupress/KuuPress.kt
+++ b/src/en/kuupress/src/eu/kanade/tachiyomi/extension/en/kuupress/KuuPress.kt
@@ -17,6 +17,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import keiyoushi.utils.getPreferencesLazy
+import keiyoushi.utils.stripChapterNumberPrefix
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -245,16 +246,12 @@ class KuuPress :
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val body = response.body.string()
-        return try {
-            val root = json.parseToJsonElement(body).jsonObject
-            val data = root["data"]?.jsonObject ?: JsonObject(emptyMap())
-            cacheBookmarkState(data.str("slug").orEmpty(), root)
-            parseChaptersFromNovelData(data)
-                .sortedByDescending { it.sortKey }
-                .map { it.chapter }
-        } catch (_: Exception) {
-            emptyList()
-        }
+        val root = json.parseToJsonElement(body).jsonObject
+        val data = root["data"]?.jsonObject ?: JsonObject(emptyMap())
+        cacheBookmarkState(data.str("slug").orEmpty(), root)
+        return parseChaptersFromNovelData(data)
+            .sortedByDescending { it.sortKey }
+            .map { it.chapter }
     }
 
     override fun fetchChapterList(manga: SManga): rx.Observable<List<SChapter>> = rx.Observable.fromCallable {
@@ -335,7 +332,17 @@ class KuuPress :
     override fun pageListParse(response: Response): List<Page> = listOf(Page(0, response.request.url.toString()))
 
     override suspend fun fetchPageText(page: Page): String {
-        val response = client.newCall(GET(if (page.url.startsWith("http")) page.url else baseUrl + page.url, headers)).execute()
+        // page.url may be the API stub (.../chapters/<id>) or the site chapter path;
+        // always resolve to the JSON content endpoint.
+        val contentUrl = if (page.url.contains("/api/public/chapters/")) {
+            page.url
+        } else {
+            val chapterId = page.url.substringBefore('?').trim('/').split('/')
+                .firstOrNull { seg -> seg.isNotEmpty() && seg.all(Char::isDigit) }
+                ?: page.url.substringAfterLast('/')
+            "$apiBase/chapters/$chapterId"
+        }
+        val response = client.newCall(GET(contentUrl, headers)).execute()
         val body = response.body.string()
 
         return try {
@@ -375,7 +382,6 @@ class KuuPress :
         SearchQueryFilter(),
     )
 
-    // ======================== Tracking ========================
 
     override val supportsChapterTracking = false
 
@@ -460,7 +466,6 @@ class KuuPress :
         return java.net.URLDecoder.decode(raw, "UTF-8")
     }
 
-    // ======================== Settings ========================
 
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
         SwitchPreferenceCompat(screen.context).apply {
@@ -563,7 +568,7 @@ class KuuPress :
                             .trim('-')
                     }
                     url = "/read/chapter/$chapterId/$chapterSlug"
-                    name = visibleTitle.ifBlank { "Chapter $sortOrder" }
+                    name = visibleTitle.stripChapterNumberPrefix().ifBlank { "Chapter $sortOrder" }
                     chapter_number = chapterNumber
                     date_upload = parseDate(chapter.str("scheduled_for") ?: chapter.str("created_at"))
                 }


### PR DESCRIPTION
fix ch content and ch errors appearing as ch content
Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
