### PR TITLE
fix(fenrirealm): strip invisible chars from titles

### DIFF
--- a/src/en/fenrirealm/build.gradle
+++ b/src/en/fenrirealm/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Fenrirealm'
     extClass = '.Fenrirealm'
-    extVersionCode = 6
+    extVersionCode = 7
     isNsfw = false
     isNovel = true
 }

--- a/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
+++ b/src/en/fenrirealm/src/eu/kanade/tachiyomi/extension/en/fenrirealm/Fenrirealm.kt
@@ -39,6 +39,8 @@ import uy.kohesive.injekt.injectLazy
 import java.text.SimpleDateFormat
 import java.util.Locale
 
+private val INVISIBLE_CHARS = Regex("[\\u200B\\u200C\\u200D\\u2060\\uFEFF]")
+
 private fun htmlToPlainTextPreserveBreaks(html: String): String {
     val document = Jsoup.parseBodyFragment(html)
     val body = document.body()
@@ -424,7 +426,7 @@ class Fenrirealm :
     ) {
         fun toSManga(baseUrl: String): SManga = SManga.create().apply {
             url = "/series/$slug"
-            this.title = this@NovelDto.title
+            this.title = this@NovelDto.title.replace(INVISIBLE_CHARS, "").trim()
             thumbnail_url = if (!cover.isNullOrEmpty()) {
                 if (cover.startsWith("http")) cover else "$baseUrl/$cover"
             } else {


### PR DESCRIPTION

Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
