### PR TITLE
fix(fictionzone): description formatting and chapter order

### DIFF
--- a/src/en/fictionzone/build.gradle
+++ b/src/en/fictionzone/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'Fiction Zone'
     extClass = '.FictionZone'
-    extVersionCode = 4
+    extVersionCode = 5
     isNovel = true
 }
 

--- a/src/en/fictionzone/src/eu/kanade/tachiyomi/extension/en/fictionzone/FictionZone.kt
+++ b/src/en/fictionzone/src/eu/kanade/tachiyomi/extension/en/fictionzone/FictionZone.kt
@@ -560,7 +560,10 @@ class FictionZone :
 
         val breakToken = "__FZ_BR__"
         val paragraphToken = "__FZ_P__"
-        val doc = Jsoup.parseBodyFragment(Parser.unescapeEntities(normalized, false))
+        // Keep plain newlines that sit between/inside tags: doc.text() would otherwise drop them,
+        // leaving only the <br>/<p> structure and collapsing the synopsis spacing.
+        val withBreaks = normalized.replace("\n", "<br>")
+        val doc = Jsoup.parseBodyFragment(Parser.unescapeEntities(withBreaks, false))
         doc.select("br").forEach { it.after(breakToken) }
         doc.select("p, div, li").forEach { it.after(paragraphToken) }
 


### PR DESCRIPTION
Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
