### PR TITLE
fix(tomatomtl): update catalog parsing and support plain JSON

### DIFF
--- a/src/en/tomatomtl/build.gradle
+++ b/src/en/tomatomtl/build.gradle
@@ -1,7 +1,7 @@
 ext {
     extName = 'TomatoMTL'
     extClass = '.TomatoMTL'
-    extVersionCode = 6
+    extVersionCode = 7
     isNovel = true
 }
 

--- a/src/en/tomatomtl/src/eu/kanade/tachiyomi/extension/en/tomatomtl/TomatoMTL.kt
+++ b/src/en/tomatomtl/src/eu/kanade/tachiyomi/extension/en/tomatomtl/TomatoMTL.kt
@@ -1308,54 +1308,48 @@ class TomatoMTL :
                 val chapterNames = mutableListOf<String>()
 
                 try {
-                    val catalogJson = json.parseToJsonElement(responseBody).jsonObject
-                    val iv = catalogJson["iv"]?.jsonPrimitive?.contentOrNull
-                    val enc = catalogJson["enc"]?.jsonPrimitive?.contentOrNull
+                    // The catalog endpoint now returns a plain JSON array of chapters.
+                    val chapterArray = resolveCatalogArray(responseBody)
 
-                    if (iv != null && enc != null) {
-                        val decrypted = decryptContent(iv, enc)
-                        Log.d("TomatoMTL", "Decrypted catalog: ${decrypted.take(500)}...")
+                    chapterArray?.forEachIndexed { index, element ->
+                        try {
+                            val chapterObj = element.jsonObject
+                            val rawTitle = chapterObj["title"]?.jsonPrimitive?.contentOrNull
+                                ?: chapterObj["name"]?.jsonPrimitive?.contentOrNull
+                                ?: "Chapter ${index + 1}"
+                            val chapterId = chapterObj["id"]?.jsonPrimitive?.contentOrNull
+                                ?: chapterObj["item_id"]?.jsonPrimitive?.contentOrNull
+                                ?: chapterObj["chapter_id"]?.jsonPrimitive?.contentOrNull
+                                ?: return@forEachIndexed
 
-                        val chapterArray = json.parseToJsonElement(decrypted).jsonArray
+                            // Decode unicode escapes and HTML entities in title
+                            val withUnicodeDecoded = decodeUnicodeEscapes(rawTitle)
+                            val chapterTitle = cleanHtml(withUnicodeDecoded)
 
-                        chapterArray.forEachIndexed { index, element ->
-                            try {
-                                val chapterObj = element.jsonObject
-                                val rawTitle = chapterObj["title"]?.jsonPrimitive?.contentOrNull
-                                    ?: chapterObj["name"]?.jsonPrimitive?.contentOrNull
-                                    ?: "Chapter ${index + 1}"
-                                val chapterId = chapterObj["id"]?.jsonPrimitive?.contentOrNull
-                                    ?: return@forEachIndexed
-
-                                // Decode unicode escapes and HTML entities in title
-                                val withUnicodeDecoded = decodeUnicodeEscapes(rawTitle)
-                                val chapterTitle = cleanHtml(withUnicodeDecoded)
-
-                                chapters.add(
-                                    SChapter.create().apply {
-                                        url = "/book/$bookId/$chapterId"
-                                        name = chapterTitle
-                                        chapter_number = (index + 1).toFloat()
-                                    },
-                                )
-                                chapterNames.add(chapterTitle)
-                            } catch (e: Exception) {
-                                Log.e("TomatoMTL", "Error parsing catalog chapter $index: ${e.message}")
-                            }
+                            chapters.add(
+                                SChapter.create().apply {
+                                    url = "/book/$bookId/$chapterId"
+                                    name = chapterTitle
+                                    chapter_number = (index + 1).toFloat()
+                                },
+                            )
+                            chapterNames.add(chapterTitle)
+                        } catch (e: Exception) {
+                            Log.e("TomatoMTL", "Error parsing catalog chapter $index: ${e.message}")
                         }
+                    }
 
-                        // Translate chapter names in batch if needed
-                        if (chapters.isNotEmpty() && chapterNames.any { needsTranslation(it) }) {
-                            try {
-                                val translatedNames = translateTitles(chapterNames)
-                                chapters.forEachIndexed { index, chapter ->
-                                    if (index < translatedNames.size) {
-                                        chapter.name = translatedNames[index]
-                                    }
+                    // Translate chapter names in batch if needed
+                    if (chapters.isNotEmpty() && chapterNames.any { needsTranslation(it) }) {
+                        try {
+                            val translatedNames = translateTitles(chapterNames)
+                            chapters.forEachIndexed { index, chapter ->
+                                if (index < translatedNames.size) {
+                                    chapter.name = translatedNames[index]
                                 }
-                            } catch (e: Exception) {
-                                Log.e("TomatoMTL", "Error translating chapter names: ${e.message}")
                             }
+                        } catch (e: Exception) {
+                            Log.e("TomatoMTL", "Error translating chapter names: ${e.message}")
                         }
                     }
                 } catch (e: Exception) {
@@ -1375,6 +1369,29 @@ class TomatoMTL :
                 emptyList<SChapter>()
             }
         }
+    }
+
+    // Resolve the chapter array from a /catalog response. Handles the current plain-array
+    // payload and the legacy encrypted {iv, enc} object (whose decrypted body is an array,
+    // or an object nesting the array under "data"/"chapters").
+    private fun resolveCatalogArray(responseBody: String): JsonArray? {
+        Log.d("TomatoMTL", "Catalog raw: ${responseBody.take(400)}")
+        val root = json.parseToJsonElement(responseBody)
+        if (root is JsonArray) return root
+        if (root !is JsonObject) return null
+
+        val iv = root["iv"]?.jsonPrimitive?.contentOrNull
+        val enc = root["enc"]?.jsonPrimitive?.contentOrNull
+        if (iv != null && enc != null) {
+            val decrypted = decryptContent(iv, enc)
+            Log.d("TomatoMTL", "Decrypted catalog: ${decrypted.take(500)}...")
+            return when (val el = json.parseToJsonElement(decrypted)) {
+                is JsonArray -> el
+                is JsonObject -> el["data"]?.jsonArray ?: el["chapters"]?.jsonArray
+                else -> null
+            }
+        }
+        return root["data"]?.jsonArray ?: root["chapters"]?.jsonArray
     }
 
     private fun isChapterUrl(href: String): Boolean {


### PR DESCRIPTION
Checklist:


- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [x] Updated `overrideVersionCode` or `baseVersionCode` as needed for all multisrc extensions
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [x] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
- [x] Have removed `web_hi_res_512.png` when adding a new extension
